### PR TITLE
Rebuild the card and dropdown in glass, and own the dropdown's window

### DIFF
--- a/.agents/skills/glass-ui-changes/SKILL.md
+++ b/.agents/skills/glass-ui-changes/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: glass-ui-changes
+description: How to change and verify the look of this app — the desktop card, the menu bar dropdown, the glass panes, borders, rims and the menu bar icon. Use whenever a task touches Glass.swift, PanelView.swift, DesktopCard.swift, UsageCard.swift, MenuBarItem.swift or StatusIcon.swift, or whenever someone says an edge, colour, shadow or border "looks off". Covers the pixel-measurement loop that has to back any claim about why something renders the way it does.
+---
+
+# Changing how the glass looks
+
+The card and the dropdown are one design language rendered by two windows. Their
+edges, sheen and tint are tuned against measured pixel values, not against
+adjectives. This skill is the loop that produced those numbers.
+
+## The rule
+
+**Never write a causal claim you have not measured.** Not in a comment, not in a
+commit message, not in a reply to the user.
+
+This exists because it was broken. A hairline on the dropdown was attributed to
+"our rim stacking on the system's", and the fix was to zero our own rim
+(`711fc03`). The stated cause was wrong, the fix changed nothing visible, and
+the wrong explanation was then baked into a comment where the next reader
+inherited it. The real cause — SwiftUI compositing its own hairline *above*
+hosted content — took ten minutes to establish once anyone actually sampled a
+pixel.
+
+Adjectives that must trigger measurement before you touch code: whiter, brighter,
+washed out, too dark, off, doesn't match, pops too much.
+
+## The loop
+
+### 1. Get the change on screen
+
+Dev builds are unreliable for this. A second copy of the app gets a status item
+the window server parks off-screen when the menu bar is crowded — its panel
+opens at a negative x and no screenshot will ever contain it. Install and drive
+the real app:
+
+```sh
+swift build && ./build.sh --install    # relaunches /Applications/AI Usage.app
+```
+
+### 2. Open the dropdown without a human
+
+```sh
+PID=$(pgrep -f "/Applications/AI Usage.app")
+osascript -e "tell application \"System Events\" to tell (first process whose unix id is $PID) to get {position, size} of menu bar item 1 of menu bar 1"
+# -> 3179, 3, 147, 24   (x, y, w, h)
+cliclick c:3252,15                     # centre of the item
+```
+
+- The app has no main menu, so the status item is **`menu bar 1`**, not `menu bar 2`.
+  (`menu bar 2` is right for apps that also own a normal menu bar.)
+- `perform action "AXPress"` does *not* open it — the button acts on mouse-up.
+  Use `cliclick`.
+- Screen coordinates here are 1:1 with screenshot pixels. Do not halve them for
+  Retina; check with the AX position before assuming.
+
+Confirm what opened, and get its exact frame:
+
+```sh
+osascript -e "tell application \"System Events\" to tell (first process whose unix id is $PID) to get {position, size} of every window"
+# positions first, then sizes: dropdown is 430x333, card is 460x283
+```
+
+### 3. Sample the pixels
+
+`screencapture -x -t png /tmp/shot.png`, then read actual values with
+`pixel.swift` in this skill directory:
+
+```sh
+swiftc .agents/skills/glass-ui-changes/pixel.swift -o /tmp/px
+/tmp/px /tmp/shot.png <y> <x0> <x1>     # prints rgb + luminance per column
+```
+
+Scan across the edge you care about, starting a few pixels outside the window
+frame. A border is one column; interior and backdrop are the columns either
+side. Quote all three when you report.
+
+### 4. Bisect with an absurd value
+
+When you cannot tell whose pixel it is, make yours unmistakable — 3pt, pure red —
+install, and sample. The answer is in the blend:
+
+- Red, clean → it is yours, and it lands where you think.
+- Red with white composited **on top** → something above you draws it, and no
+  change inside the view tree can cover it.
+- No red at the edge at all → your stroke is not where you think it is (check
+  `strokeBorder`'s inward inset and the corner radius).
+
+That single test is what settled the hairline. Reach for it early; it is cheaper
+than an argument.
+
+## Facts already established
+
+Do not re-derive these, and do not undo them.
+
+- **`MenuBarExtra(.window)` is unusable for this design.** Its window draws a
+  ~white-0.6 hairline over the content it hosts. It cannot be removed, covered or
+  dimmed from inside the view tree. The dropdown is therefore an app-owned
+  borderless `NSPanel` (`MenuBarItem.swift`), the same way the card is
+  (`DesktopCard.swift`). Do not go back to `MenuBarExtra`.
+- **The panel and the card both draw their own rim** via `glassPane`. The panel's
+  edge measures ~109 luminance over a ~51 interior; the card's ~161 over ~128.
+  Same white rim — the dropdown's simply sits on a darker pane (`dim: 0.75`), so
+  the contrast ratio is higher. If it is asked to be softer, scale `border` on
+  the panel's `glassPane`; do not touch `Glass.rim`, which the card shares.
+- **Shadows are the window's**, never SwiftUI's — pass `shadow: false` to
+  `glassPane` in anything hosted in a panel. A SwiftUI shadow is clipped by the
+  window it is drawn inside.
+- **A dumped layer tree is evidence.** An `NSViewRepresentable` that walks
+  `window.contentView?.superview` and prints each layer's `borderWidth`,
+  `borderColor` and `backgroundColor` will tell you the alpha of your own stroke,
+  which is usually enough to exonerate it. Delete the probe before committing.
+
+## Provider marks
+
+The Claude and OpenAI outlines in `Resources/Icons` are parsed once by
+`BrandGlyph` and shared by the menu bar (`StatusIcon`), the card and the
+dropdown (`BrandMark` in `UsageCard.swift`). AppKit's y runs up and SwiftUI's
+runs down, which is what `path(for:fitting:flipped:)` is for — a mark that comes
+out upside down is a flip argument, not a broken SVG.
+
+They stay monochrome and uniformly scaled. Never tint them with pace colour,
+stretch them or rotate them; the marks are trademarks and the colour belongs on
+the ring and the track beside them.
+
+## Before you report
+
+- Screenshot the result and look at it.
+- Quote the numbers you measured, not your reasoning about them.
+- Say plainly what you could not verify. An unverified surface is a caveat, not
+  a rounding error.

--- a/.agents/skills/glass-ui-changes/pixel.swift
+++ b/.agents/skills/glass-ui-changes/pixel.swift
@@ -1,0 +1,42 @@
+import AppKit
+
+// Prints the colour of one horizontal run of pixels from a screenshot, so a
+// claim about an edge can be checked instead of argued.
+//
+//   swiftc pixel.swift -o /tmp/px
+//   /tmp/px /tmp/shot.png 200 3176 3188
+//
+// Arguments: <image> <y> <x0> <x1>, in image pixels with the origin top left.
+// Split the luminance maths across lines — as one expression the type checker
+// gives up on it.
+
+guard CommandLine.arguments.count == 5 else {
+    print("usage: px <image> <y> <x0> <x1>")
+    exit(2)
+}
+
+let url = URL(fileURLWithPath: CommandLine.arguments[1])
+guard let y = Int(CommandLine.arguments[2]),
+      let x0 = Int(CommandLine.arguments[3]),
+      let x1 = Int(CommandLine.arguments[4]),
+      x0 <= x1
+else {
+    print("y, x0 and x1 must be integers, and x0 <= x1")
+    exit(2)
+}
+
+guard let image = NSImage(contentsOf: url),
+      let bitmap = image.representations.first as? NSBitmapImageRep
+else {
+    print("could not read \(url.path)")
+    exit(1)
+}
+
+for x in x0...x1 {
+    guard let colour = bitmap.colorAt(x: x, y: y) else { continue }
+    let r: Double = colour.redComponent * 255
+    let g: Double = colour.greenComponent * 255
+    let b: Double = colour.blueComponent * 255
+    let luminance: Double = 0.299 * r + 0.587 * g + 0.114 * b
+    print("x=\(x) rgb=\(Int(r)),\(Int(g)),\(Int(b)) lum=\(Int(luminance))")
+}

--- a/.agents/skills/writing-skills/SKILL.md
+++ b/.agents/skills/writing-skills/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: writing-skills
+description: How to write a new skill for this project, or fix an existing one — file layout under .agents/skills, the symlink into .claude/skills, frontmatter rules, what belongs in a skill versus a comment or CLAUDE.md, and how to tell a useful skill from a wasted one. Use when asked to "learn this", "make a skill", "remember how to do X", "write this up so it doesn't happen again", or when a mistake is worth not repeating.
+---
+
+# Writing a skill
+
+A skill is a note to the next agent, written by the one who just paid for the
+lesson. It earns its place by changing what that agent does — not by describing
+what the code already says.
+
+## Layout
+
+Skills live in `.agents/skills/` and are exposed to Claude Code by a symlink per
+skill:
+
+```sh
+mkdir -p .agents/skills/<name> .claude/skills
+$EDITOR .agents/skills/<name>/SKILL.md
+ln -s ../../.agents/skills/<name> .claude/skills/<name>
+```
+
+Relative symlink, always — an absolute one breaks the moment the repo is cloned,
+moved, or opened in another Conductor workspace. Check it from the repo root:
+
+```sh
+ls -l .claude/skills/          # -> <name> -> ../../.agents/skills/<name>
+cat .claude/skills/<name>/SKILL.md | head -3
+```
+
+`.agents/` holds the real files so other agent runners can be pointed at the
+same directory; `.claude/skills/` is one runner's view of it. Both are committed.
+
+Supporting files sit beside `SKILL.md` in the same directory and are referenced
+from it by path — a script to run, a template to copy, a reference table too long
+for the body. Anything the skill tells you to run should be a file you can run,
+not a snippet to retype.
+
+## Frontmatter
+
+```yaml
+---
+name: kebab-case-matching-the-directory
+description: What it covers, and the situations that should pull it in.
+---
+```
+
+`description` is the only thing an agent sees before deciding whether to open the
+skill, so it is the whole retrieval mechanism. Write it as triggers, not as a
+title:
+
+- Name the files, symbols and commands the work would touch.
+- Include the words a user would actually type, including vague ones ("looks
+  off", "still broken", "make it match").
+- Prefer one long, specific sentence over three vague ones.
+
+A description like "UI helpers" is a skill that will never be read.
+
+## What belongs in one
+
+Write a skill when the knowledge is **procedural, reusable and non-obvious**:
+
+- A loop that works — how to drive, observe and verify something in this project.
+- A dead end with a proof — what does not work and the evidence that settled it,
+  so nobody re-litigates it.
+- A rule that was learned the hard way, with the failure that produced it.
+
+Do not write a skill for:
+
+- What the code already states plainly. Comment the code instead.
+- A one-off fix with no next time.
+- Project-wide conventions that belong in `CLAUDE.md`.
+- Anything you have not verified. A confident, wrong skill is worse than none —
+  it launders a guess into an instruction.
+
+## How to write it
+
+- **Lead with the rule, then the scar.** The rule is what gets followed; the
+  story of the failure is what makes it stick, and it needs to be one paragraph,
+  not a post-mortem.
+- **Be concrete.** Real commands, real paths, real numbers, real output. If a
+  command has a gotcha (`menu bar 1` not `menu bar 2`, `cliclick` not `AXPress`),
+  that gotcha *is* the value of the skill.
+- **Record the facts already established** as a list the next agent can trust,
+  so the expensive parts are not re-derived.
+- **Say what to do, in order.** A skill is a procedure with the reasoning
+  attached, not an essay with a procedure buried in it.
+- **Keep it short enough to be read.** Cut anything that does not change an
+  action.
+
+## Updating one
+
+When a skill turns out to be wrong, fix it in place and delete the wrong claim —
+do not append a correction underneath it. Two contradicting paragraphs cost the
+next agent more than silence would have. If the underlying code moved, check the
+skill still names files and symbols that exist before recommending it.

--- a/.claude/skills/glass-ui-changes
+++ b/.claude/skills/glass-ui-changes
@@ -1,0 +1,1 @@
+../../.agents/skills/glass-ui-changes

--- a/.claude/skills/writing-skills
+++ b/.claude/skills/writing-skills
@@ -1,0 +1,1 @@
+../../.agents/skills/writing-skills

--- a/README.md
+++ b/README.md
@@ -52,23 +52,32 @@ busiest. Tick *Always keep every provider on screen* to hand each provider a
 slot first instead, so a quiet Codex stays visible beside a loud Claude at the
 cost of bumping a window that really is busier. The window's initial sits in the hole
 of the ring (`w` week, `h` 5-hour, `s` spark week), which is the one place a
-menu bar has room to spare. Click it for the full card, a **Refresh** button and
-settings.
+menu bar has room to spare. Click it for the dropdown.
 
-**Desktop card.** The same card, free-standing. Drag it anywhere; the position
-is remembered by its top left corner, so it stays put when a row appears. It
-sits just above the desktop icons and behind every window by default — tick
-*Keep card above other windows* to float it instead. Right-click it for refresh,
-hide and quit.
+**Dropdown.** Two tabs on a pane of glass. *Usage* leads with one line saying
+whether you are fine — "On pace everywhere", or how far ahead of an even burn
+the worst window is — then a row per window, with a **Refresh** button beside
+the tabs. *Settings* holds everything else, so opening it can no longer push the
+reading off the bottom of the screen.
+
+**Desktop card.** The same reading, free-standing and roomier: a ring for the
+worst window, the summary line, and a block per provider with a word for how
+that provider on its own is doing. The whole card lights red from the inside
+once a window is in trouble, so the state survives peripheral vision. Drag it
+anywhere; the position is remembered by its top left corner, so it stays put
+when a row appears. It sits just above the desktop icons and behind every window
+by default — set *Card layer* to *Floating* to keep it in front instead.
+Right-click it for refresh, hide and quit.
 
 **Notifications.** One alert when a window passes your threshold, one when it is
 burning faster than your pace multiple. Each fires at most once per window; the
 moment a window resets, the slate is wiped and the next crossing is announced
 again.
 
-Settings live behind the gear: which menu bar parts to draw and how many
-windows, desktop card on/off and its level, open at login, both alert
-thresholds, and the refresh interval.
+The Settings tab groups them the way System Settings does: *Menu bar* (which
+parts to draw, how many windows), *Display* (desktop card on/off, its layer,
+open at login), *Alerts* (both thresholds, on sliders rather than steppers), and
+*Refresh* (5, 15, 30 or 60 minutes).
 
 ### Why not a WidgetKit widget
 
@@ -91,6 +100,7 @@ bar ring, the dropdown and the desktop card can never disagree.
 | `Report.swift` | the JSON written to the cache |
 | `Pace.swift` | elapsed share, pace ratio, colours, reset labels |
 | `UsageCard.swift` | the reading, shared by the dropdown and the desktop card |
+| `Glass.swift` | the glass surfaces, tracks, ring and controls both are built from |
 | `StatusIcon.swift` | the menu bar item — logo, ring, percentage |
 | `BrandGlyph.swift` | reads `Resources/Icons/*.svg` into drawable outlines |
 | `Notifier.swift` | threshold and pace alerts, one per window instance |
@@ -153,7 +163,7 @@ alive with `pgrep -fl "AI Usage"`, then look in your manager's hidden section.
 **Desktop card missing**
 
 By default it sits behind every window, so a maximised window hides it. Show the
-desktop, or tick *Keep card above other windows*. If it was dragged to a screen
+desktop, or set *Card layer* to *Floating*. If it was dragged to a screen
 that is no longer attached, it comes back to the top right on the next launch.
 
 **No notifications**

--- a/Sources/AIUsage/AIUsageApp.swift
+++ b/Sources/AIUsage/AIUsageApp.swift
@@ -1,17 +1,16 @@
+import AppKit
 import SwiftUI
 
+/// Plain AppKit rather than a SwiftUI `App`: the only scene this ever had was a
+/// `MenuBarExtra`, and that window comes with chrome we cannot turn off — see
+/// `MenuBarItem`. Without it there is no scene left to declare.
 @main
-struct AIUsageApp: App {
-    @NSApplicationDelegateAdaptor(AppDelegate.self) private var delegate
-    @StateObject private var store = UsageStore.shared
-
-    var body: some Scene {
-        MenuBarExtra {
-            PanelView().environmentObject(store)
-        } label: {
-            Image(nsImage: store.statusImage)
-        }
-        .menuBarExtraStyle(.window)
+enum AIUsageApp {
+    static func main() {
+        let application = NSApplication.shared
+        let delegate = AppDelegate()
+        application.delegate = delegate
+        application.run()
     }
 }
 
@@ -22,6 +21,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.accessory)
         Notifier.requestAuthorization()
         MainActor.assumeIsolated {
+            MenuBarItem.shared.start()
             DesktopCard.shared.start()
         }
     }

--- a/Sources/AIUsage/BrandGlyph.swift
+++ b/Sources/AIUsage/BrandGlyph.swift
@@ -1,9 +1,9 @@
 import AppKit
 
-/// The provider marks drawn in the menu bar, read as SVG outlines from
-/// `Resources/Icons` rather than as image assets: the files stay legible and
-/// replaceable, and one outline scales to any menu bar height where a bitmap
-/// would need a set.
+/// The provider marks drawn in the menu bar, on the card and in the dropdown,
+/// read as SVG outlines from `Resources/Icons` rather than as image assets: the
+/// files stay legible and replaceable, and one outline scales to any size where
+/// a bitmap would need a set.
 ///
 /// Outlines taken from simple-icons, whose packaging is CC0; the marks
 /// themselves remain trademarks of their owners. So they are only ever drawn
@@ -12,10 +12,13 @@ import AppKit
 enum BrandGlyph {
     /// Nil for a provider with no mark on file; the caller falls back to a
     /// monogram, which is also what an unreadable or unparseable outline gets.
-    static func path(for provider: String, fitting box: NSSize) -> NSBezierPath? {
+    ///
+    /// `flipped` suits AppKit, whose y runs upwards. SwiftUI's runs downwards,
+    /// the same way the outlines are authored, so it asks for the mark as is.
+    static func path(for provider: String, fitting box: NSSize, flipped: Bool = true) -> NSBezierPath? {
         guard let file = files[provider.lowercased()] else { return nil }
         guard let parsed = cache.path(for: file) else { return nil }
-        return fit(parsed, in: box)
+        return fit(parsed, in: box, flipped: flipped)
     }
 
     /// Where the outlines live. `build.sh` copies the directory into the
@@ -62,17 +65,20 @@ enum BrandGlyph {
     }
 
     /// Both outlines are authored in a 24×24 box with y running downwards, so
-    /// fitting one means flipping it and centring it on the shorter side.
-    private static func fit(_ path: NSBezierPath, in box: NSSize) -> NSBezierPath {
+    /// fitting one means centring it on the shorter side, and flipping it for
+    /// a caller whose y runs the other way.
+    private static func fit(_ path: NSBezierPath, in box: NSSize, flipped: Bool) -> NSBezierPath {
         let side = min(box.width, box.height)
         let scale = side / 24
 
-        let transform = AffineTransform(translationByX: (box.width - side) / 2, byY: (box.height + side) / 2)
-        var flip = transform
-        flip.scale(x: scale, y: -scale)
+        var transform = AffineTransform(
+            translationByX: (box.width - side) / 2,
+            byY: (box.height + (flipped ? side : -side)) / 2
+        )
+        transform.scale(x: scale, y: flipped ? -scale : scale)
 
         let copy = path.copy() as! NSBezierPath
-        copy.transform(using: flip)
+        copy.transform(using: transform)
         return copy
     }
 }

--- a/Sources/AIUsage/DesktopCard.swift
+++ b/Sources/AIUsage/DesktopCard.swift
@@ -15,7 +15,7 @@ final class DesktopCard {
     private var observers: [NSObjectProtocol] = []
     private var isRepositioning = false
 
-    private let width: CGFloat = 300
+    private let width: CGFloat = 460
     private let inset: CGFloat = 30
 
     private init() {}
@@ -151,16 +151,23 @@ final class DesktopCard {
 // --------------------------------------------------------------------- //
 
 /// The card plus the chrome that only makes sense free-standing on the desktop.
+///
+/// The pane goes red from the inside once the worst window is in trouble — the
+/// card is glanced at, not read, so the state has to survive peripheral vision.
 private struct CardWindowView: View {
     @EnvironmentObject private var store: UsageStore
 
     var body: some View {
-        UsageCard()
-            .padding(EdgeInsets(top: 14, leading: 16, bottom: 12, trailing: 16))
-            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .strokeBorder(.white.opacity(0.08))
+        let hot = Pace.verdict(store.report).hot
+
+        DesktopUsageCard()
+            .padding(EdgeInsets(top: 20, leading: 22, bottom: 18, trailing: 22))
+            // The drop shadow is the panel's own: a SwiftUI one would be
+            // clipped by the window it is drawn inside.
+            .glassPane(
+                radius: Glass.cardRadius,
+                tint: hot ? Color(red: 1, green: 0.471, blue: 0.471) : nil,
+                shadow: false
             )
             .contextMenu {
                 Button("Refresh now") {

--- a/Sources/AIUsage/Glass.swift
+++ b/Sources/AIUsage/Glass.swift
@@ -1,0 +1,380 @@
+import SwiftUI
+
+/// The material vocabulary the card and the dropdown are both built from:
+/// a blurred pane, a diagonal sheen over it, a bright top lip, and controls
+/// that read as cut into the glass rather than drawn on top of it.
+///
+/// Every surface is dark by construction — the sheen is white over blur, so a
+/// light appearance would wash the text out. Roots set `\.colorScheme` to dark
+/// rather than each call site guessing.
+enum Glass {
+    static let cardRadius: CGFloat = 22
+    static let panelRadius: CGFloat = 20
+    static let groupRadius: CGFloat = 14
+
+    /// Text on glass. The design works in white at five or six opacities.
+    static func ink(_ opacity: Double) -> Color { .white.opacity(opacity) }
+
+    /// linear-gradient(155deg, …) — the diagonal lift across the pane.
+    static func sheen(tint: Color = .white, top: Double = 0.18, bottom: Double = 0.06) -> LinearGradient {
+        LinearGradient(
+            colors: [tint.opacity(top), .white.opacity(bottom)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    /// `inset 0 1px 0 rgba(255,255,255,0.4)`: a lit top edge that falls away
+    /// down the sides, which is what makes the pane read as thick.
+    static func rim(top: Double = 0.4, bottom: Double = 0.1, tint: Color = .white) -> LinearGradient {
+        LinearGradient(
+            colors: [tint.opacity(top), tint.opacity(bottom)],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+    }
+
+    /// The divider used inside a pane: visible in the middle, gone at the ends.
+    static var hairline: some View {
+        LinearGradient(
+            colors: [.white.opacity(0.02), .white.opacity(0.18), .white.opacity(0.02)],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+        .frame(height: 1)
+    }
+}
+
+extension View {
+    /// A whole pane of glass — the desktop card and the dropdown.
+    ///
+    /// `tint` colours the sheen and the border together, which is how the hot
+    /// state is expressed: the same card, lit red from inside.
+    func glassPane(
+        radius: CGFloat,
+        tint: Color? = nil,
+        shadow: Bool = true
+    ) -> some View {
+        let sheen = Glass.sheen(tint: tint ?? .white, top: tint == nil ? 0.18 : 0.20)
+        let border = Glass.rim(top: tint == nil ? 0.4 : 0.34, bottom: 0.08, tint: tint ?? .white)
+
+        return background {
+            RoundedRectangle(cornerRadius: radius, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: radius, style: .continuous).fill(sheen)
+                )
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: radius, style: .continuous)
+                .strokeBorder(border, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(shadow ? 0.45 : 0), radius: 28, y: 14)
+        .environment(\.colorScheme, .dark)
+    }
+
+    /// An inset group inside a pane — the pattern System Settings uses, and
+    /// what keeps the settings tab from reading as one undifferentiated list.
+    func glassGroup(padding: EdgeInsets = EdgeInsets(top: 14, leading: 14, bottom: 14, trailing: 14)) -> some View {
+        self.padding(padding)
+            .background(
+                RoundedRectangle(cornerRadius: Glass.groupRadius, style: .continuous)
+                    .fill(Color.white.opacity(0.07))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Glass.groupRadius, style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.11), lineWidth: 1)
+            )
+    }
+}
+
+// --------------------------------------------------------------------- //
+// Readings
+// --------------------------------------------------------------------- //
+
+/// The consumption bar: a groove cut into the glass, a fill that glows, and
+/// the even-burn mark as a notch straight through both.
+struct UsageTrack: View {
+    let percent: Double
+    let elapsed: Double?
+    let palette: Pace.Palette
+    var height: CGFloat = 10
+    var glows: Bool = true
+
+    var body: some View {
+        GeometryReader { geometry in
+            let width = geometry.size.width
+            let radius = height * 0.6
+
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .fill(
+                        Color.black.opacity(0.22)
+                            .shadow(.inner(color: .black.opacity(0.45), radius: 1.5, y: 1))
+                            .shadow(.inner(color: .white.opacity(0.10), radius: 0.5, y: -1))
+                    )
+
+                fill(in: width, radius: radius)
+
+                // Where usage *should* be if spent evenly across the window.
+                if let elapsed, elapsed > 0 {
+                    RoundedRectangle(cornerRadius: 1, style: .continuous)
+                        .fill(Color.white.opacity(0.85))
+                        .frame(width: 2, height: height + 6)
+                        .shadow(color: .black.opacity(0.4), radius: 3)
+                        .offset(x: min(width - 2, width * elapsed / 100 - 1))
+                }
+            }
+        }
+        .frame(height: height)
+    }
+
+    /// An untouched window still gets a stub, so the row reads as a track with
+    /// nothing in it rather than as a track that failed to draw.
+    @ViewBuilder
+    private func fill(in width: CGFloat, radius: CGFloat) -> some View {
+        let idle = percent < 0.5
+        let drawn = max(6, width * min(100, max(0, percent)) / 100)
+
+        RoundedRectangle(cornerRadius: radius, style: .continuous)
+            .fill(idle ? Pace.idleFill : palette.fill)
+            .frame(width: idle ? 6 : drawn)
+            .shadow(color: glows && !idle ? palette.base.opacity(0.55) : .clear, radius: 6)
+    }
+}
+
+/// The donut in the summary line: one glance at the worst window.
+struct PaceRing: View {
+    let percent: Double
+    let color: Color
+    var size: CGFloat = 40
+
+    var body: some View {
+        let line = size * 0.185
+        ZStack {
+            Circle().strokeBorder(Color.white.opacity(0.18), lineWidth: line)
+            Circle()
+                .inset(by: line / 2)
+                .trim(from: 0, to: min(1, max(0.005, percent / 100)))
+                .stroke(color, style: StrokeStyle(lineWidth: line, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+// --------------------------------------------------------------------- //
+// Controls
+// --------------------------------------------------------------------- //
+
+/// The pill segmented control, used for the tabs, the card layer and the
+/// refresh interval. AppKit's own segmented control cannot be made to sit on
+/// glass without bringing its own opaque chrome along.
+struct GlassSegmented<Value: Hashable>: View {
+    struct Option: Identifiable {
+        let value: Value
+        let label: String
+        var id: Value { value }
+
+        init(_ value: Value, _ label: String) {
+            self.value = value
+            self.label = label
+        }
+    }
+
+    let options: [Option]
+    @Binding var selection: Value
+    var fontSize: CGFloat = 12
+    var verticalPadding: CGFloat = 6
+    var enabled: Bool = true
+
+    @Namespace private var slider
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(options) { option in
+                let chosen = option.value == selection
+
+                Button {
+                    withAnimation(.snappy(duration: 0.18)) { selection = option.value }
+                } label: {
+                    Text(option.label)
+                        .font(.system(size: fontSize, weight: chosen ? .semibold : .regular))
+                        .foregroundStyle(Glass.ink(chosen ? 1 : 0.6))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, verticalPadding)
+                        .contentShape(Rectangle())
+                        .background {
+                            if chosen {
+                                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                                    .fill(Color.white.opacity(0.24))
+                                    .shadow(color: .black.opacity(0.3), radius: 2, y: 1)
+                                    .matchedGeometryEffect(id: "chosen", in: slider)
+                            }
+                        }
+                }
+                .buttonStyle(.plain)
+                // The system ring is drawn as a hard rectangle around the whole
+                // segment and cuts straight across the pill.
+                .focusEffectDisabled()
+            }
+        }
+        .padding(2)
+        .background(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .fill(Color.black.opacity(0.24))
+        )
+        .opacity(enabled ? 1 : 0.45)
+        .disabled(!enabled)
+    }
+}
+
+/// A threshold slider. Coarse adjustment by dragging beats aiming at an 8pt
+/// stepper arrow, which is what the old settings pane asked for.
+struct GlassSlider: View {
+    @Binding var value: Double
+    let range: ClosedRange<Double>
+    var step: Double = 1
+    var colors: [Color] = [Pace.warn, Pace.bad]
+    var enabled: Bool = true
+
+    private let knob: CGFloat = 16
+    private let track: CGFloat = 6
+
+    var body: some View {
+        GeometryReader { geometry in
+            let width = geometry.size.width
+            let travel = max(1, width - knob)
+            let fraction = min(1, max(0, (value - range.lowerBound) / (range.upperBound - range.lowerBound)))
+
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.black.opacity(0.26))
+                    .frame(height: track)
+
+                Capsule()
+                    .fill(LinearGradient(colors: colors, startPoint: .leading, endPoint: .trailing))
+                    .frame(width: knob / 2 + travel * fraction, height: track)
+
+                Circle()
+                    .fill(.white)
+                    .frame(width: knob, height: knob)
+                    .shadow(color: .black.opacity(0.4), radius: 2, y: 1)
+                    .offset(x: travel * fraction)
+            }
+            .frame(height: knob, alignment: .center)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0).onChanged { drag in
+                    guard enabled else { return }
+                    let position = min(1, max(0, (drag.location.x - knob / 2) / travel))
+                    let raw = range.lowerBound + position * (range.upperBound - range.lowerBound)
+                    let snapped = (raw / step).rounded() * step
+                    value = min(range.upperBound, max(range.lowerBound, snapped))
+                }
+            )
+        }
+        .frame(height: knob)
+        .opacity(enabled ? 1 : 0.45)
+    }
+}
+
+/// A row in an inset group: label, optional second line, control on the right.
+struct SettingRow<Control: View>: View {
+    let title: String
+    var subtitle: String?
+    var enabled: Bool = true
+    @ViewBuilder let control: Control
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 13))
+                    .foregroundStyle(Glass.ink(enabled ? 0.92 : 0.4))
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.system(size: 11))
+                        .foregroundStyle(Glass.ink(0.45))
+                }
+            }
+            Spacer(minLength: 8)
+            control
+        }
+    }
+}
+
+/// A switch that matches the design's green pill without giving up the system
+/// control's animation, hit area or keyboard handling.
+struct GlassSwitch: View {
+    @Binding var isOn: Bool
+    var enabled: Bool = true
+
+    var body: some View {
+        Toggle("", isOn: $isOn)
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .tint(Pace.good)
+            .controlSize(.small)
+            .disabled(!enabled)
+            .opacity(enabled ? 1 : 0.45)
+    }
+}
+
+/// The small glass button in a header — refresh, settings.
+struct GlassButton: View {
+    let label: String
+    var systemImage: String?
+    var prominent: Bool = false
+    var enabled: Bool = true
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                if let systemImage {
+                    Image(systemName: systemImage).font(.system(size: 12, weight: .medium))
+                }
+                if !label.isEmpty {
+                    Text(label).font(.system(size: 12, weight: .medium))
+                }
+            }
+            .foregroundStyle(Glass.ink(0.95))
+            .padding(.horizontal, label.isEmpty ? 8 : 11)
+            .padding(.vertical, 5)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.white.opacity(prominent ? 0.24 : 0.14))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.18), lineWidth: 1)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .focusEffectDisabled()
+        .disabled(!enabled)
+        .opacity(enabled ? 1 : 0.45)
+    }
+}
+
+/// The plain text action the design puts in a footer — "Quit".
+struct GlassLink: View {
+    let title: String
+    let action: () -> Void
+
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 12))
+                .foregroundStyle(Glass.ink(hovering ? 0.95 : 0.62))
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .focusEffectDisabled()
+        .onHover { hovering = $0 }
+    }
+}

--- a/Sources/AIUsage/Glass.swift
+++ b/Sources/AIUsage/Glass.swift
@@ -143,10 +143,13 @@ struct UsageTrack: View {
     }
 }
 
-/// The donut in the summary line: one glance at the worst window.
+/// The donut in the summary line: one glance at the worst window. Carries the
+/// same even-burn mark as the tracks, so "how much is gone" and "how far into
+/// the window we are" are read off one shape.
 struct PaceRing: View {
     let percent: Double
     let color: Color
+    var elapsed: Double? = nil
     var size: CGFloat = 40
 
     var body: some View {
@@ -158,6 +161,15 @@ struct PaceRing: View {
                 .trim(from: 0, to: min(1, max(0.005, percent / 100)))
                 .stroke(color, style: StrokeStyle(lineWidth: line, lineCap: .round))
                 .rotationEffect(.degrees(-90))
+
+            if let elapsed, elapsed > 0 {
+                Capsule()
+                    .fill(Color.white.opacity(0.85))
+                    .frame(width: 2, height: line + 5)
+                    .shadow(color: .black.opacity(0.4), radius: 2)
+                    .offset(y: -(size - line) / 2)
+                    .rotationEffect(.degrees(min(100, elapsed) / 100 * 360))
+            }
         }
         .frame(width: size, height: size)
     }

--- a/Sources/AIUsage/Glass.swift
+++ b/Sources/AIUsage/Glass.swift
@@ -50,9 +50,13 @@ extension View {
     ///
     /// `tint` colours the sheen and the border together, which is how the hot
     /// state is expressed: the same card, lit red from inside.
+    /// `saturation` is the design's `backdrop-filter: saturate(180%)`: the blur
+    /// alone greys out whatever is behind the pane, and putting the colour back
+    /// is most of what makes it read as glass rather than as fog.
     func glassPane(
         radius: CGFloat,
         tint: Color? = nil,
+        saturation: Double = 1,
         shadow: Bool = true
     ) -> some View {
         let sheen = Glass.sheen(tint: tint ?? .white, top: tint == nil ? 0.18 : 0.20)
@@ -61,6 +65,7 @@ extension View {
         return background {
             RoundedRectangle(cornerRadius: radius, style: .continuous)
                 .fill(.ultraThinMaterial)
+                .saturation(saturation)
                 .overlay(
                     RoundedRectangle(cornerRadius: radius, style: .continuous).fill(sheen)
                 )

--- a/Sources/AIUsage/Glass.swift
+++ b/Sources/AIUsage/Glass.swift
@@ -319,6 +319,8 @@ struct GlassSegmented<Value: Hashable>: View {
 struct GlassSlider: View {
     @Binding var value: Double
     let range: ClosedRange<Double>
+    let accessibilityLabel: String
+    let accessibilityValue: String
     var step: Double = 1
     var colors: [Color] = [Pace.warn, Pace.bad]
     var enabled: Bool = true
@@ -361,6 +363,35 @@ struct GlassSlider: View {
         }
         .frame(height: knob)
         .opacity(enabled ? 1 : 0.45)
+        .focusable(enabled)
+        .onKeyPress(keys: [.leftArrow, .downArrow, .rightArrow, .upArrow]) { press in
+            switch press.key {
+            case .leftArrow, .downArrow:
+                adjust(by: -1)
+            case .rightArrow, .upArrow:
+                adjust(by: 1)
+            default:
+                return .ignored
+            }
+            return .handled
+        }
+        .disabled(!enabled)
+        // Keep the glass control on screen, but let assistive technologies
+        // operate the native slider semantics they already understand.
+        .accessibilityRepresentation {
+            Slider(value: $value, in: range, step: step) {
+                Text(accessibilityLabel)
+            }
+            .accessibilityValue(accessibilityValue)
+            .disabled(!enabled)
+        }
+    }
+
+    private func adjust(by steps: Double) {
+        guard enabled else { return }
+        let raw = value + steps * step
+        let snapped = (raw / step).rounded() * step
+        value = min(range.upperBound, max(range.lowerBound, snapped))
     }
 }
 

--- a/Sources/AIUsage/Glass.swift
+++ b/Sources/AIUsage/Glass.swift
@@ -24,11 +24,21 @@ enum Glass {
         )
     }
 
-    /// `inset 0 1px 0 rgba(255,255,255,0.4)`: a lit top edge that falls away
-    /// down the sides, which is what makes the pane read as thick.
-    static func rim(top: Double = 0.4, bottom: Double = 0.1, tint: Color = .white) -> LinearGradient {
+    /// The border and the lit top edge in one stroke.
+    ///
+    /// The design keeps them separate — `border: 1px rgba(255,255,255,0.2)` all
+    /// the way round, and `inset 0 1px 0 rgba(255,255,255,0.4)` only along the
+    /// top. Running a single gradient from 0.4 down to 0.08 instead spread the
+    /// bright end across the whole upper half: the left border measured 184
+    /// where the design measures 85. So the bright stop now ends within the
+    /// first few percent of the height and the rest holds at `base`.
+    static func rim(top: Double = 0.35, base: Double = 0.2, tint: Color = .white) -> LinearGradient {
         LinearGradient(
-            colors: [tint.opacity(top), tint.opacity(bottom)],
+            stops: [
+                .init(color: tint.opacity(top), location: 0),
+                .init(color: tint.opacity(base), location: 0.05),
+                .init(color: tint.opacity(base), location: 1),
+            ],
             startPoint: .top,
             endPoint: .bottom
         )
@@ -72,29 +82,29 @@ enum Glass {
 extension View {
     /// A whole pane of glass — the desktop card and the dropdown.
     ///
-    /// `tint` colours the sheen and the border together, which is how the hot
-    /// state is expressed: the same card, lit red from inside.
-    /// `saturation` is the design's `backdrop-filter: saturate(180%)`: the blur
-    /// alone greys out whatever is behind the pane, and putting the colour back
-    /// is most of what makes it read as glass rather than as fog.
-    /// `lift` scales the sheen. The design's pane has no dark layer under it at
-    /// all — blur, saturate, then a white gradient — so the gradient lands on a
-    /// lit backdrop and the pane comes out light. SwiftUI's material in the
-    /// dark appearance is itself a dark translucency, so the same gradient
-    /// lands on slate and the pane goes flat. Rendering the blur light instead
-    /// overshoots badly: the pane turns milky and white text stops reading.
-    /// Lifting the gradient closes the gap from the other side.
-    /// `lift` scales the head of the sheen and `falloff` its tail, because the
-    /// two ends wanted different answers: measured against the design, the pane
-    /// was right at the top left with the sheen at full strength and right at
-    /// the bottom right with it at a third of that. Scaling both together could
-    /// only ever satisfy one end.
+    /// The knobs exist because the two surfaces sit in different windows, and
+    /// the same values do not come out the same on both.
+    ///
+    /// - `tint` colours the sheen and the rim together, which is how the hot
+    ///   state is expressed: the same card, lit red from inside.
+    /// - `lift` scales the head of the sheen and `falloff` its tail. Measured
+    ///   against the design, the pane wanted full strength at the top left and
+    ///   a third of it at the bottom right, so scaling both together could only
+    ///   ever satisfy one end.
+    /// - `tone` puts back the colour the blur loses; see `Glass.tone`.
+    /// - `border` scales the rim. The menu bar window draws a hairline of its
+    ///   own that nothing in its hierarchy accounts for — the frame view is
+    ///   empty and transparent, yet its edge measures 180 where the pane
+    ///   measures 50, while the desktop card's edge measures 145 against a
+    ///   predicted 144. Ours was landing on top of the system's and reading as
+    ///   a white outline, so the dropdown asks for a fraction of it.
     func glassPane(
         radius: CGFloat,
         tint: Color? = nil,
         lift: Double = 1,
         falloff: Double = 0.06,
         tone: Double = 0,
+        border: Double = 1,
         shadow: Bool = true
     ) -> some View {
         let sheen = Glass.sheen(
@@ -102,7 +112,12 @@ extension View {
             top: (tint == nil ? 0.18 : 0.20) * lift,
             bottom: falloff
         )
-        let border = Glass.rim(top: tint == nil ? 0.4 : 0.34, bottom: 0.08, tint: tint ?? .white)
+        // The hot state borrows the design's red border, `rgba(255,140,140,0.34)`.
+        let rim = Glass.rim(
+            top: (tint == nil ? 0.35 : 0.36) * border,
+            base: (tint == nil ? 0.2 : 0.34) * border,
+            tint: tint ?? .white
+        )
         let shape = RoundedRectangle(cornerRadius: radius, style: .continuous)
 
         return background {
@@ -115,7 +130,7 @@ extension View {
         }
         .overlay(
             RoundedRectangle(cornerRadius: radius, style: .continuous)
-                .strokeBorder(border, lineWidth: 1)
+                .strokeBorder(rim, lineWidth: 1)
         )
         .shadow(color: .black.opacity(shadow ? 0.45 : 0), radius: 28, y: 14)
         .environment(\.colorScheme, .dark)

--- a/Sources/AIUsage/Glass.swift
+++ b/Sources/AIUsage/Glass.swift
@@ -44,24 +44,30 @@ enum Glass {
         )
     }
 
-    /// The colour a blurred backdrop loses on the way through.
+    /// The design's blue, laid over the blur.
     ///
-    /// The design ends its blur with `saturate(180%)`, which is what makes the
-    /// pane read as blue glass rather than as slate. SwiftUI has no equivalent:
-    /// materials are composited by the window server, below the level a
-    /// `.saturation` modifier reaches, so the filter is a no-op on them. The
-    /// wallpaper behind the panel measures 0.56 saturation and the pane came
-    /// out at 0.21 against the design's 0.55.
+    /// The mock ends its backdrop-filter with `saturate(180%)`, which is what
+    /// makes the pane read as blue glass rather than as slate. SwiftUI has no
+    /// equivalent — materials are composited by the window server, below the
+    /// level a `.saturation` modifier reaches — so the colour goes on top of
+    /// the blur instead of being recovered from it. Sampled from the mock.
     ///
-    /// So the colour goes back on top of the blur instead of being recovered
-    /// from it. The trade is that the pane no longer tracks a backdrop of a
-    /// different hue — it is glass with a colour of its own, rather than glass
-    /// that takes the colour of what is behind it.
+    /// The trade is that the pane no longer takes the hue of whatever is behind
+    /// it. Over a blue desktop that is invisible; over an orange window it will
+    /// stay blue, exactly as the mock does.
+    ///
+    /// The mock's own stops are too light to use directly. It was drawn over a
+    /// lit teal canvas, so its top stop is `(69,118,144)` — luminance 110,
+    /// against a wallpaper that measures 47. Laying that over a dark corner of
+    /// the screen lightens the pane rather than colouring it, which is what
+    /// left the dropdown pale beside the card even with the sheen thinned. The
+    /// hue and the diagonal are the mock's; the luminance is roughly halved so
+    /// the colour lands without the lift.
     static func tone(_ strength: Double) -> LinearGradient {
         LinearGradient(
             colors: [
-                Color(red: 0.271, green: 0.463, blue: 0.565).opacity(0.58 * strength),
-                Color(red: 0.086, green: 0.188, blue: 0.263).opacity(0.92 * strength),
+                Color(red: 0.149, green: 0.255, blue: 0.311).opacity(0.58 * strength),
+                Color(red: 0.055, green: 0.121, blue: 0.169).opacity(0.92 * strength),
             ],
             startPoint: .topLeading,
             endPoint: .bottomTrailing
@@ -82,16 +88,21 @@ enum Glass {
 extension View {
     /// A whole pane of glass — the desktop card and the dropdown.
     ///
-    /// The knobs exist because the two surfaces sit in different windows, and
-    /// the same values do not come out the same on both.
-    ///
     /// - `tint` colours the sheen and the rim together, which is how the hot
     ///   state is expressed: the same card, lit red from inside.
-    /// - `lift` scales the head of the sheen and `falloff` its tail. Measured
-    ///   against the design, the pane wanted full strength at the top left and
-    ///   a third of it at the bottom right, so scaling both together could only
-    ///   ever satisfy one end.
-    /// - `tone` puts back the colour the blur loses; see `Glass.tone`.
+    /// - `dim` eases off the sheen. Translucent glass pulls whatever is behind
+    ///   it towards its own mid-tone, so the same pane darkens a bright
+    ///   backdrop and lightens a dark one: measured over the wallpaper, the
+    ///   card came out 31 below its backdrop and the dropdown 23 above its own.
+    ///   The card can be dragged onto whatever suits it; the dropdown is pinned
+    ///   under the menu bar, so it has to hold up over a dark corner.
+    ///
+    ///   It works on the sheen rather than by laying black over the blur, which
+    ///   was the first attempt: the white gradient is what adds the 23, and a
+    ///   scrim heavy enough to cancel it also cancels the blur, leaving a flat
+    ///   dark panel with no glass left in it. Thinning the white keeps the
+    ///   backdrop showing through, which is the whole effect.
+    /// - `tone` lays the design's blue over the blur; see `Glass.tone`.
     /// - `border` scales the rim. The menu bar window draws a hairline of its
     ///   own that nothing in its hierarchy accounts for — the frame view is
     ///   empty and transparent, yet its edge measures 180 where the pane
@@ -101,16 +112,15 @@ extension View {
     func glassPane(
         radius: CGFloat,
         tint: Color? = nil,
-        lift: Double = 1,
-        falloff: Double = 0.06,
-        tone: Double = 0,
         border: Double = 1,
+        dim: Double = 0,
+        tone: Double = 0,
         shadow: Bool = true
     ) -> some View {
         let sheen = Glass.sheen(
             tint: tint ?? .white,
-            top: (tint == nil ? 0.18 : 0.20) * lift,
-            bottom: falloff
+            top: (tint == nil ? 0.18 : 0.20) * (1 - dim),
+            bottom: 0.06 * (1 - dim)
         )
         // The hot state borrows the design's red border, `rgba(255,140,140,0.34)`.
         let rim = Glass.rim(

--- a/Sources/AIUsage/Glass.swift
+++ b/Sources/AIUsage/Glass.swift
@@ -34,6 +34,30 @@ enum Glass {
         )
     }
 
+    /// The colour a blurred backdrop loses on the way through.
+    ///
+    /// The design ends its blur with `saturate(180%)`, which is what makes the
+    /// pane read as blue glass rather than as slate. SwiftUI has no equivalent:
+    /// materials are composited by the window server, below the level a
+    /// `.saturation` modifier reaches, so the filter is a no-op on them. The
+    /// wallpaper behind the panel measures 0.56 saturation and the pane came
+    /// out at 0.21 against the design's 0.55.
+    ///
+    /// So the colour goes back on top of the blur instead of being recovered
+    /// from it. The trade is that the pane no longer tracks a backdrop of a
+    /// different hue — it is glass with a colour of its own, rather than glass
+    /// that takes the colour of what is behind it.
+    static func tone(_ strength: Double) -> LinearGradient {
+        LinearGradient(
+            colors: [
+                Color(red: 0.271, green: 0.463, blue: 0.565).opacity(0.58 * strength),
+                Color(red: 0.086, green: 0.188, blue: 0.263).opacity(0.92 * strength),
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
     /// The divider used inside a pane: visible in the middle, gone at the ends.
     static var hairline: some View {
         LinearGradient(
@@ -53,22 +77,41 @@ extension View {
     /// `saturation` is the design's `backdrop-filter: saturate(180%)`: the blur
     /// alone greys out whatever is behind the pane, and putting the colour back
     /// is most of what makes it read as glass rather than as fog.
+    /// `lift` scales the sheen. The design's pane has no dark layer under it at
+    /// all — blur, saturate, then a white gradient — so the gradient lands on a
+    /// lit backdrop and the pane comes out light. SwiftUI's material in the
+    /// dark appearance is itself a dark translucency, so the same gradient
+    /// lands on slate and the pane goes flat. Rendering the blur light instead
+    /// overshoots badly: the pane turns milky and white text stops reading.
+    /// Lifting the gradient closes the gap from the other side.
+    /// `lift` scales the head of the sheen and `falloff` its tail, because the
+    /// two ends wanted different answers: measured against the design, the pane
+    /// was right at the top left with the sheen at full strength and right at
+    /// the bottom right with it at a third of that. Scaling both together could
+    /// only ever satisfy one end.
     func glassPane(
         radius: CGFloat,
         tint: Color? = nil,
-        saturation: Double = 1,
+        lift: Double = 1,
+        falloff: Double = 0.06,
+        tone: Double = 0,
         shadow: Bool = true
     ) -> some View {
-        let sheen = Glass.sheen(tint: tint ?? .white, top: tint == nil ? 0.18 : 0.20)
+        let sheen = Glass.sheen(
+            tint: tint ?? .white,
+            top: (tint == nil ? 0.18 : 0.20) * lift,
+            bottom: falloff
+        )
         let border = Glass.rim(top: tint == nil ? 0.4 : 0.34, bottom: 0.08, tint: tint ?? .white)
+        let shape = RoundedRectangle(cornerRadius: radius, style: .continuous)
 
         return background {
-            RoundedRectangle(cornerRadius: radius, style: .continuous)
+            shape
                 .fill(.ultraThinMaterial)
-                .saturation(saturation)
-                .overlay(
-                    RoundedRectangle(cornerRadius: radius, style: .continuous).fill(sheen)
-                )
+                // Colour first, then the sheen over it — the white gradient is
+                // meant to lift the glass, not to be tinted by it.
+                .overlay(tone > 0 ? shape.fill(Glass.tone(tone)) : nil)
+                .overlay(shape.fill(sheen))
         }
         .overlay(
             RoundedRectangle(cornerRadius: radius, style: .continuous)

--- a/Sources/AIUsage/MenuBarItem.swift
+++ b/Sources/AIUsage/MenuBarItem.swift
@@ -19,6 +19,7 @@ final class MenuBarItem {
     private var panel: NSPanel?
     private var watches: Set<AnyCancellable> = []
     private var monitors: [Any] = []
+    private var activationObserver: NSObjectProtocol?
 
     /// Clear of the menu bar, and clear of the shadow the panel casts upwards.
     private let dropGap: CGFloat = 6
@@ -83,8 +84,21 @@ final class MenuBarItem {
 
         panel.makeKeyAndOrderFront(nil)
 
-        // A menu closes when you click away from it. `resignKey` alone does not
-        // cover a click on our own desktop card, which never takes key.
+        // A nonactivating panel leaves whichever app was already frontmost in
+        // that state. Close when another app becomes frontmost, which covers a
+        // keyboard app switch without interfering with the status item's own
+        // click-to-toggle action.
+        activationObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.close() }
+        }
+
+        // A menu also closes when you click away from it. The activation
+        // observer alone does not cover a click on our own desktop card, which
+        // never takes key.
         monitors = [
             NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] _ in
                 MainActor.assumeIsolated { self?.close() }
@@ -106,6 +120,10 @@ final class MenuBarItem {
     }
 
     private func close() {
+        if let activationObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(activationObserver)
+            self.activationObserver = nil
+        }
         monitors.forEach(NSEvent.removeMonitor)
         monitors = []
         panel?.orderOut(nil)

--- a/Sources/AIUsage/MenuBarItem.swift
+++ b/Sources/AIUsage/MenuBarItem.swift
@@ -1,0 +1,140 @@
+import AppKit
+import Combine
+import SwiftUI
+
+/// The menu bar item and the panel it drops down, owned outright rather than
+/// left to `MenuBarExtra(.window)`.
+///
+/// SwiftUI's menu bar window draws a hairline of its own *over* whatever it
+/// hosts — measured at 173 luminance against a pane of 50, and a 3pt red test
+/// stroke came back with a white edge on top of it, so it is composited above
+/// the content and cannot be covered from inside the view tree. That line is
+/// the whole reason the dropdown never matched the card. A panel of our own has
+/// no chrome, so the pane's own rim is the only edge there is.
+@MainActor
+final class MenuBarItem {
+    static let shared = MenuBarItem()
+
+    private var item: NSStatusItem?
+    private var panel: NSPanel?
+    private var watches: Set<AnyCancellable> = []
+    private var monitors: [Any] = []
+
+    /// Clear of the menu bar, and clear of the shadow the panel casts upwards.
+    private let dropGap: CGFloat = 6
+    /// How close the panel may come to the screen edge when the item sits near
+    /// the corner and the panel would otherwise hang off it.
+    private let screenInset: CGFloat = 8
+
+    private init() {}
+
+    func start() {
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        item.button?.image = UsageStore.shared.statusImage
+        item.button?.target = self
+        item.button?.action = #selector(toggle)
+        item.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
+        self.item = item
+
+        UsageStore.shared.$statusImage
+            .sink { [weak self] image in self?.item?.button?.image = image }
+            .store(in: &watches)
+    }
+
+    // ----------------------------------------------------------------- //
+
+    @objc private func toggle() {
+        if panel != nil {
+            close()
+        } else {
+            open()
+        }
+    }
+
+    private func open() {
+        let content = PanelView()
+            .environmentObject(UsageStore.shared)
+        let hosting = NSHostingController(rootView: content)
+        // The panel is two tabs of different heights, and the settings one
+        // grows as the list does.
+        hosting.sizingOptions = [.preferredContentSize]
+
+        let panel = DropdownPanel(
+            contentRect: NSRect(origin: .zero, size: hosting.view.fittingSize),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.contentViewController = hosting
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.hidesOnDeactivate = false
+        panel.level = .popUpMenu
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle, .fullScreenAuxiliary]
+        self.panel = panel
+
+        // As with the card: the hosting controller only publishes its size on
+        // the next pass, and the panel has to be placed at its real size now or
+        // it lands as if it were zero wide.
+        hosting.view.layoutSubtreeIfNeeded()
+        panel.setContentSize(hosting.view.fittingSize)
+        place(panel)
+
+        panel.makeKeyAndOrderFront(nil)
+
+        // A menu closes when you click away from it. `resignKey` alone does not
+        // cover a click on our own desktop card, which never takes key.
+        monitors = [
+            NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] _ in
+                MainActor.assumeIsolated { self?.close() }
+            },
+            // The item's own window is left to the button action, which
+            // toggles: closing here first would have it reopen on the same
+            // click and the dropdown could never be clicked shut.
+            NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] event in
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    let ours = event.window === panel || event.window === self.item?.button?.window
+                    if !ours { self.close() }
+                }
+                return event
+            },
+        ].compactMap { $0 }
+
+        item?.button?.highlight(true)
+    }
+
+    private func close() {
+        monitors.forEach(NSEvent.removeMonitor)
+        monitors = []
+        panel?.orderOut(nil)
+        panel = nil
+        item?.button?.highlight(false)
+    }
+
+    /// Hung under the menu bar item, left edges aligned the way a menu is, and
+    /// pulled back onto the screen when the item is close enough to the corner
+    /// that the panel would otherwise overhang it.
+    private func place(_ panel: NSPanel) {
+        guard let button = item?.button, let barWindow = button.window else { return }
+        let item = barWindow.convertToScreen(button.convert(button.bounds, to: nil))
+        let screen = barWindow.screen ?? NSScreen.main
+        let size = panel.frame.size
+
+        var x = item.minX
+        if let visible = screen?.visibleFrame {
+            x = min(x, visible.maxX - size.width - screenInset)
+            x = max(x, visible.minX + screenInset)
+        }
+        panel.setFrameOrigin(NSPoint(x: x, y: item.minY - dropGap - size.height))
+    }
+}
+
+// --------------------------------------------------------------------- //
+
+/// A borderless panel refuses key by default, which would leave the settings
+/// tab's switches and sliders dead to the keyboard and the first click.
+private final class DropdownPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+}

--- a/Sources/AIUsage/Pace.swift
+++ b/Sources/AIUsage/Pace.swift
@@ -8,6 +8,25 @@ enum Pace {
     static let warn = Color(red: 1.000, green: 0.706, blue: 0.329)   // #ffb454
     static let bad = Color(red: 1.000, green: 0.420, blue: 0.420)    // #ff6b6b
 
+    /// The three shades a filled track is drawn in. The flat colour is what the
+    /// menu bar and the ring use; the gradient is what gives the fill in a
+    /// recessed groove its curvature.
+    struct Palette {
+        let base: Color
+        let top: Color
+        let bottom: Color
+
+        var fill: LinearGradient {
+            LinearGradient(colors: [top, bottom], startPoint: .top, endPoint: .bottom)
+        }
+    }
+
+    static let idleFill = LinearGradient(
+        colors: [.white.opacity(0.5), .white.opacity(0.3)],
+        startPoint: .top,
+        endPoint: .bottom
+    )
+
     struct Severity: Comparable {
         let tier: Int
         let percent: Double
@@ -48,6 +67,29 @@ enum Pace {
         }
     }
 
+    static func palette(_ window: UsageWindow, now: Date = Date()) -> Palette {
+        switch severityTier(window, now: now) {
+        case 2:
+            return Palette(
+                base: bad,
+                top: Color(red: 1.000, green: 0.604, blue: 0.604),   // #ff9a9a
+                bottom: Color(red: 0.902, green: 0.310, blue: 0.310)  // #e64f4f
+            )
+        case 1:
+            return Palette(
+                base: warn,
+                top: Color(red: 1.000, green: 0.816, blue: 0.541),   // #ffd08a
+                bottom: Color(red: 0.941, green: 0.604, blue: 0.188)  // #f09a30
+            )
+        default:
+            return Palette(
+                base: good,
+                top: Color(red: 0.549, green: 0.910, blue: 0.678),   // #8ce8ad
+                bottom: Color(red: 0.294, green: 0.722, blue: 0.478)  // #4bb87a
+            )
+        }
+    }
+
     private static func severityTier(_ window: UsageWindow, now: Date) -> Int {
         if window.percent >= 90 { return 2 }
         guard let ratio = ratio(window, now: now) else {
@@ -70,6 +112,86 @@ enum Pace {
             percent: window.percent,
             pace: ratio(window, now: now) ?? 0
         )
+    }
+
+    /// One sentence answering "am I fine?", so neither surface makes the reader
+    /// parse four rows to find out.
+    struct Verdict {
+        /// Title of the dropdown's summary pill, over `detail`.
+        let headline: String
+        /// The card's one line, which has to carry the number as well.
+        let line: String
+        let detail: String
+        let percent: Double
+        let color: Color
+        /// True once the reading is bad enough that the whole card goes red.
+        let hot: Bool
+    }
+
+    static func verdict(_ report: Report?, now: Date = Date()) -> Verdict {
+        guard let worst = report?.busiestWindows(limit: 1, now: now).first else {
+            return Verdict(
+                headline: "No reading yet",
+                line: "No reading yet",
+                detail: "nothing fetched",
+                percent: 0,
+                color: good,
+                hot: false
+            )
+        }
+
+        let window = worst.window
+        let tier = severityTier(window, now: now)
+        let percent = Int(window.percent.rounded())
+        let burn = burnPhrase(window, now: now)
+        let exhausted = tier == 2 && window.percent >= 90
+
+        let short: String
+        switch tier {
+        case 2: short = burn ?? "Well ahead of pace"
+        case 1: short = burn ?? "Ahead of pace"
+        default: short = "On pace"
+        }
+
+        return Verdict(
+            headline: exhausted ? "\(window.label) window nearly out" : (tier == 0 ? "On pace everywhere" : short),
+            line: exhausted
+                ? [burn, "\(window.label) window nearly out"].compactMap { $0 }.joined(separator: " — ")
+                : "\(short) — \(percent)% of \(phrase(window.label))",
+            detail: "worst: \(worst.provider.name) \(window.label), \(percent)%",
+            percent: window.percent,
+            color: color(window, now: now),
+            hot: tier == 2
+        )
+    }
+
+    /// Window labels are a mix of periods and durations: "the week" reads, but
+    /// "the 5h" does not and needs the noun spelling out.
+    private static func phrase(_ label: String) -> String {
+        let period = ["week", "day", "month", "hour", "session"].contains { label.contains($0) }
+        return period ? "the \(label)" : "the \(label) window"
+    }
+
+    /// "Burning 2.1× pace" — only once the window has run long enough for the
+    /// ratio to mean anything, otherwise the phrase would be invented.
+    private static func burnPhrase(_ window: UsageWindow, now: Date) -> String? {
+        guard let ratio = ratio(window, now: now), ratio > 1 else { return nil }
+        return String(format: "Burning %.1f× pace", ratio)
+    }
+
+    /// The word beside a provider's name: how that provider on its own is doing.
+    static func note(_ provider: Provider, now: Date = Date()) -> (text: String, color: Color) {
+        guard provider.ok else { return (provider.error ?? "unavailable", bad) }
+        guard let worst = provider.windows.max(by: { severity($0, now: now) < severity($1, now: now) })
+        else { return ("no windows", .white.opacity(0.45)) }
+
+        if worst.percent < 5 { return ("barely touched", .white.opacity(0.45)) }
+        switch severityTier(worst, now: now) {
+        case 2 where worst.percent >= 90: return ("nearly out", bad)
+        case 2: return ("over budget", bad)
+        case 1: return ("ahead of pace", warn)
+        default: return ("under budget", good)
+        }
     }
 
     /// Absolute reset time. Bare clock today, weekday within the week, and a

--- a/Sources/AIUsage/Pace.swift
+++ b/Sources/AIUsage/Pace.swift
@@ -57,6 +57,14 @@ enum Pace {
         return window.percent / elapsed
     }
 
+    /// The same reading as a percentage, which is how the summary states it:
+    /// spending measured against the even-burn mark on the track rather than
+    /// against the whole budget. 100 sits exactly on the mark, 150 is half
+    /// again past it. Nil while the mark is still too early to mean anything.
+    static func paceIndex(_ window: UsageWindow, now: Date = Date()) -> Double? {
+        ratio(window, now: now).map { $0 * 100 }
+    }
+
     /// Green while spending is at or under the even-burn pace, orange when
     /// running ahead of it, red when far ahead or nearly exhausted.
     static func color(_ window: UsageWindow, now: Date = Date()) -> Color {
@@ -123,6 +131,13 @@ enum Pace {
         let line: String
         let detail: String
         let percent: Double
+        /// Share of the window elapsed, for the ring's even-burn mark.
+        let elapsed: Double?
+        /// "Anthropic 5h" — the row the whole summary is speaking about, named
+        /// so that the ring is not an anonymous number.
+        let source: String?
+        /// Identifies that row in the list below, so it can be marked there too.
+        let rowKey: String?
         let color: Color
         /// True once the reading is bad enough that the whole card goes red.
         let hot: Bool
@@ -135,6 +150,9 @@ enum Pace {
                 line: "No reading yet",
                 detail: "nothing fetched",
                 percent: 0,
+                elapsed: nil,
+                source: nil,
+                rowKey: nil,
                 color: good,
                 hot: false
             )
@@ -142,27 +160,39 @@ enum Pace {
 
         let window = worst.window
         let tier = severityTier(window, now: now)
-        let percent = Int(window.percent.rounded())
-        let burn = burnPhrase(window, now: now)
         let exhausted = tier == 2 && window.percent >= 90
+        let reading = readingPhrase(window, now: now)
 
         let short: String
         switch tier {
-        case 2: short = burn ?? "Well ahead of pace"
-        case 1: short = burn ?? "Ahead of pace"
+        case 2: short = "Well ahead of pace"
+        case 1: short = "Ahead of pace"
         default: short = "On pace"
         }
 
         return Verdict(
             headline: exhausted ? "\(window.label) window nearly out" : (tier == 0 ? "On pace everywhere" : short),
             line: exhausted
-                ? [burn, "\(window.label) window nearly out"].compactMap { $0 }.joined(separator: " — ")
-                : "\(short) — \(percent)% of \(phrase(window.label))",
-            detail: "worst: \(worst.provider.name) \(window.label), \(percent)%",
+                ? "\(window.label) window nearly out — \(reading)"
+                : "\(short) — \(reading)",
+            detail: "worst: \(worst.provider.name) \(window.label), \(reading)",
             percent: window.percent,
+            elapsed: elapsedPercent(window, now: now),
+            source: "\(worst.provider.name) \(window.label)",
+            rowKey: Report.rowKey(provider: worst.provider, window: window),
             color: color(window, now: now),
             hot: tier == 2
         )
+    }
+
+    /// The number the summary quotes. Against the even-burn mark once there is
+    /// one, since "63% of the week" says nothing about whether that is early or
+    /// late; against the budget only while the window is too young for a mark.
+    private static func readingPhrase(_ window: UsageWindow, now: Date) -> String {
+        if let index = paceIndex(window, now: now) {
+            return "\(Int(index.rounded()))% of pace"
+        }
+        return "\(Int(window.percent.rounded()))% of \(phrase(window.label))"
     }
 
     /// Window labels are a mix of periods and durations: "the week" reads, but
@@ -170,13 +200,6 @@ enum Pace {
     private static func phrase(_ label: String) -> String {
         let period = ["week", "day", "month", "hour", "session"].contains { label.contains($0) }
         return period ? "the \(label)" : "the \(label) window"
-    }
-
-    /// "Burning 2.1× pace" — only once the window has run long enough for the
-    /// ratio to mean anything, otherwise the phrase would be invented.
-    private static func burnPhrase(_ window: UsageWindow, now: Date) -> String? {
-        guard let ratio = ratio(window, now: now), ratio > 1 else { return nil }
-        return String(format: "Burning %.1f× pace", ratio)
     }
 
     /// The word beside a provider's name: how that provider on its own is doing.

--- a/Sources/AIUsage/PanelView.swift
+++ b/Sources/AIUsage/PanelView.swift
@@ -1,172 +1,363 @@
 import AppKit
 import SwiftUI
 
-/// The dropdown behind the menu bar item: the reading, plus the controls a
-/// desktop card had nowhere to put.
+/// The dropdown behind the menu bar item, in two tabs. Settings used to push
+/// the reading off the bottom of the screen when opened; as a tab it costs one
+/// click and keeps the panel a constant height instead.
 struct PanelView: View {
+    enum Tab: Hashable {
+        case usage
+        case settings
+    }
+
     @EnvironmentObject private var store: UsageStore
-    @State private var showingSettings = false
+    @State private var tab: Tab = .usage
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            UsageCard()
+        VStack(spacing: 0) {
+            header
 
-            Divider()
+            switch tab {
+            case .usage:
+                VStack(alignment: .leading, spacing: 16) {
+                    MenuUsageView()
+                    usageFooter
+                }
+                .padding(EdgeInsets(top: 4, leading: 18, bottom: 18, trailing: 18))
 
-            if showingSettings {
-                SettingsView()
-                Divider()
+            case .settings:
+                SettingsTab()
             }
-
-            footer
         }
-        .padding(14)
-        .frame(width: 320)
+        .frame(width: 430)
+        .background {
+            Rectangle()
+                .fill(.ultraThinMaterial)
+                .overlay(Rectangle().fill(Glass.sheen(top: 0.17)))
+        }
+        .environment(\.colorScheme, .dark)
         .onAppear { store.refreshIfStale(olderThan: 300) }
     }
 
-    private var footer: some View {
+    private var header: some View {
         HStack(spacing: 8) {
-            Button("Refresh") {
-                Task { await store.refresh() }
-            }
-            .disabled(store.isRefreshing)
+            GlassSegmented(
+                options: [.init(.usage, "Usage"), .init(.settings, "Settings")],
+                selection: $tab
+            )
 
-            Button {
-                showingSettings.toggle()
-            } label: {
-                Image(systemName: "gearshape")
-            }
-            .help("Settings")
-
-            Spacer()
-
-            Button("Quit") {
-                NSApplication.shared.terminate(nil)
+            if tab == .usage {
+                GlassButton(label: "", systemImage: "arrow.clockwise", enabled: !store.isRefreshing) {
+                    Task { await store.refresh() }
+                }
+                .help("Refresh now")
             }
         }
-        .font(.system(size: 11))
-        .buttonStyle(.borderless)
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
+    }
+
+    private var usageFooter: some View {
+        HStack(spacing: 12) {
+            Text(footerText)
+                .font(.system(size: 11))
+                .foregroundStyle(Glass.ink(0.4))
+            Spacer(minLength: 8)
+            GlassLink(title: "Quit") { NSApplication.shared.terminate(nil) }
+        }
+    }
+
+    private var footerText: String {
+        let every = "every \(Int(Preferences.shared.refreshMinutes)) min"
+        guard let report = store.report else { return "No reading yet · \(every)" }
+        if store.isRefreshing { return "Refreshing… · \(every)" }
+        let stale = report.isStale ? " (stale)" : ""
+        return "Updated \(report.updatedLabel)\(stale) · \(every)"
     }
 }
 
 // --------------------------------------------------------------------- //
 
-private struct SettingsView: View {
+/// Settings as inset groups rather than one flat run of checkboxes: switches
+/// for the on/off knobs, segmented controls for the either/or ones, and
+/// sliders for the thresholds that used to be ±5 arithmetic on a stepper.
+private struct SettingsTab: View {
     @EnvironmentObject private var store: UsageStore
     @ObservedObject private var preferences = Preferences.shared
     @State private var opensAtLogin = Preferences.shared.opensAtLogin
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("MENU BAR")
-                .font(.system(size: 9, weight: .medium))
-                .kerning(0.6)
-                .foregroundStyle(.tertiary)
-
-            HStack(spacing: 14) {
-                partToggle("Logo", isOn: $preferences.showLogoInMenuBar)
-                partToggle("Gauge", isOn: $preferences.showGaugeInMenuBar)
-                partToggle("Percent", isOn: $preferences.showPercentInMenuBar)
-            }
-
-            // Rides inside the gauge rather than beside it, so it widens
-            // nothing — and has nowhere to go once the gauge is off.
-            Toggle("Mark the window inside the gauge (w, h)", isOn: $preferences.showWindowInMenuBar)
-                .disabled(!preferences.showGaugeInMenuBar)
-                .onChange(of: preferences.showWindowInMenuBar) { _, _ in
-                    store.iconPreferenceChanged()
+        VStack(alignment: .leading, spacing: 0) {
+            // Capped and scrolled rather than allowed to grow: the whole point
+            // of the tab is that the dropdown stays a predictable height.
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    menuBarGroup
+                    displayGroup
+                    alertsGroup
+                    refreshGroup
                 }
-
-            Stepper(value: $preferences.menuBarSlots, in: 1...4) {
-                Text(preferences.menuBarSlots == 1
-                    ? "Show the busiest window"
-                    : "Show the \(preferences.menuBarSlots) busiest windows")
+                .padding(EdgeInsets(top: 4, leading: 18, bottom: 14, trailing: 18))
             }
-            .onChange(of: preferences.menuBarSlots) { _, _ in
-                store.iconPreferenceChanged()
-            }
+            .scrollIndicators(.never)
+            .frame(maxHeight: 380)
 
-            Toggle("Always keep every provider on screen", isOn: $preferences.menuBarFairShare)
-                .disabled(preferences.menuBarSlots == 1)
-                .onChange(of: preferences.menuBarFairShare) { _, _ in
-                    store.iconPreferenceChanged()
-                }
-
-            Divider()
-
-            Toggle("Show card on desktop", isOn: $preferences.showDesktopCard)
-            Toggle("Keep card above other windows", isOn: $preferences.desktopCardFloats)
-                .disabled(!preferences.showDesktopCard)
-                .padding(.leading, 18)
-
-            Toggle("Open at login", isOn: $opensAtLogin)
-                .onChange(of: opensAtLogin) { _, wanted in
-                    let actual = preferences.setOpensAtLogin(wanted)
-                    if actual != wanted { opensAtLogin = actual }
-                }
-
-            Divider()
-
-            Toggle("Alert past", isOn: $preferences.usageAlertsEnabled)
-            stepperRow(
-                value: $preferences.usageThreshold,
-                range: 50...100,
-                step: 5,
-                enabled: preferences.usageAlertsEnabled,
-                text: "\(Int(preferences.usageThreshold))% of a window"
-            )
-
-            Toggle("Alert when burning faster than", isOn: $preferences.paceAlertsEnabled)
-            stepperRow(
-                value: $preferences.paceThreshold,
-                range: 1.1...4,
-                step: 0.1,
-                enabled: preferences.paceAlertsEnabled,
-                text: String(format: "%.1f× the even pace", preferences.paceThreshold)
-            )
-
-            Divider()
-
-            stepperRow(
-                value: $preferences.refreshMinutes,
-                range: 1...120,
-                step: 5,
-                enabled: true,
-                text: "Refresh every \(Int(preferences.refreshMinutes)) min"
-            )
+            // Quit stays put instead of hiding at the bottom of the scroll.
+            footer
+                .padding(EdgeInsets(top: 0, leading: 18, bottom: 18, trailing: 18))
         }
-        .font(.system(size: 11))
-        .toggleStyle(.checkbox)
+    }
+
+    // ----------------------------------------------------------------- //
+
+    private var menuBarGroup: some View {
+        Group {
+            groupTitle("Menu bar")
+
+            DividedRows {
+                SettingRow(title: "Provider logo") {
+                    partSwitch($preferences.showLogoInMenuBar)
+                }
+                SettingRow(title: "Usage gauge") {
+                    partSwitch($preferences.showGaugeInMenuBar)
+                }
+                SettingRow(title: "Percentage") {
+                    partSwitch($preferences.showPercentInMenuBar)
+                }
+                SettingRow(
+                    title: "Window initial in the gauge",
+                    subtitle: "rides inside the ring, so it widens nothing",
+                    enabled: preferences.showGaugeInMenuBar
+                ) {
+                    GlassSwitch(isOn: $preferences.showWindowInMenuBar, enabled: preferences.showGaugeInMenuBar)
+                        .onChange(of: preferences.showWindowInMenuBar) { _, _ in
+                            store.iconPreferenceChanged()
+                        }
+                }
+                SettingRow(title: "Windows shown") {
+                    GlassSegmented(
+                        options: (1...4).map { .init($0, "\($0)") },
+                        selection: $preferences.menuBarSlots,
+                        fontSize: 11,
+                        verticalPadding: 4
+                    )
+                    .frame(width: 132)
+                    .onChange(of: preferences.menuBarSlots) { _, _ in
+                        store.iconPreferenceChanged()
+                    }
+                }
+                SettingRow(
+                    title: "Keep every provider on screen",
+                    subtitle: "even when one provider owns the busiest windows",
+                    enabled: preferences.menuBarSlots > 1
+                ) {
+                    GlassSwitch(isOn: $preferences.menuBarFairShare, enabled: preferences.menuBarSlots > 1)
+                        .onChange(of: preferences.menuBarFairShare) { _, _ in
+                            store.iconPreferenceChanged()
+                        }
+                }
+            }
+        }
+    }
+
+    private var displayGroup: some View {
+        Group {
+            groupTitle("Display")
+
+            DividedRows {
+                SettingRow(title: "Card on desktop") {
+                    GlassSwitch(isOn: $preferences.showDesktopCard)
+                }
+                SettingRow(title: "Card layer", enabled: preferences.showDesktopCard) {
+                    GlassSegmented(
+                        options: [.init(false, "Desktop"), .init(true, "Floating")],
+                        selection: $preferences.desktopCardFloats,
+                        fontSize: 11,
+                        verticalPadding: 4,
+                        enabled: preferences.showDesktopCard
+                    )
+                    .frame(width: 160)
+                }
+                SettingRow(title: "Open at login") {
+                    GlassSwitch(isOn: $opensAtLogin)
+                        .onChange(of: opensAtLogin) { _, wanted in
+                            let actual = preferences.setOpensAtLogin(wanted)
+                            if actual != wanted { opensAtLogin = actual }
+                        }
+                }
+            }
+        }
+    }
+
+    private var alertsGroup: some View {
+        Group {
+            groupTitle("Alerts")
+
+            VStack(alignment: .leading, spacing: 16) {
+                threshold(
+                    title: "Alert past",
+                    value: String(format: "%.0f%%", preferences.usageThreshold),
+                    isOn: $preferences.usageAlertsEnabled,
+                    slider: $preferences.usageThreshold,
+                    range: 50...100,
+                    step: 5,
+                    colors: [Pace.warn, Color(red: 1, green: 0.549, blue: 0.235)],
+                    bounds: ("50%", "100%")
+                )
+
+                threshold(
+                    title: "Alert when burning faster than",
+                    value: String(format: "%.1f×", preferences.paceThreshold),
+                    isOn: $preferences.paceAlertsEnabled,
+                    slider: $preferences.paceThreshold,
+                    range: 1.1...4,
+                    step: 0.1,
+                    colors: [Pace.warn, Pace.bad],
+                    bounds: ("1.1×", "4×")
+                )
+            }
+            .glassGroup()
+        }
+    }
+
+    private var refreshGroup: some View {
+        Group {
+            groupTitle("Refresh")
+
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Refresh every")
+                    .font(.system(size: 13))
+                    .foregroundStyle(Glass.ink(0.92))
+
+                GlassSegmented(
+                    options: [.init(5.0, "5"), .init(15.0, "15"), .init(30.0, "30"), .init(60.0, "60 min")],
+                    selection: $preferences.refreshMinutes
+                )
+            }
+            .glassGroup()
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 12) {
+            Text("v\(Self.version) · io.github.ai-usage")
+                .font(.system(size: 11))
+                .foregroundStyle(Glass.ink(0.4))
+            Spacer(minLength: 8)
+            GlassLink(title: "Quit") { NSApplication.shared.terminate(nil) }
+        }
+    }
+
+    private static var version: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev"
+    }
+
+    // ----------------------------------------------------------------- //
+
+    private func groupTitle(_ text: String) -> some View {
+        Text(text.uppercased())
+            .font(.system(size: 10, weight: .medium))
+            .kerning(1.3)
+            .foregroundStyle(Glass.ink(0.42))
+            .padding(.leading, 4)
+            .padding(.top, 2)
+    }
+
+    private func threshold(
+        title: String,
+        value: String,
+        isOn: Binding<Bool>,
+        slider: Binding<Double>,
+        range: ClosedRange<Double>,
+        step: Double,
+        colors: [Color],
+        bounds: (String, String)
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack(spacing: 10) {
+                Text(title)
+                    .font(.system(size: 13))
+                    .foregroundStyle(Glass.ink(isOn.wrappedValue ? 0.92 : 0.4))
+                Spacer(minLength: 8)
+                Text(value)
+                    .font(.system(size: 13, weight: .semibold))
+                    .monospacedDigit()
+                    .foregroundStyle(Glass.ink(isOn.wrappedValue ? 1 : 0.4))
+                GlassSwitch(isOn: isOn)
+            }
+
+            GlassSlider(
+                value: slider,
+                range: range,
+                step: step,
+                colors: colors,
+                enabled: isOn.wrappedValue
+            )
+
+            HStack {
+                Text(bounds.0)
+                Spacer()
+                Text(bounds.1)
+            }
+            .font(.system(size: 10))
+            .monospacedDigit()
+            .foregroundStyle(Glass.ink(0.35))
+        }
     }
 
     /// The last part standing is locked on: a menu bar item with nothing drawn
     /// in it cannot be clicked back open to undo the mistake.
-    private func partToggle(_ title: String, isOn: Binding<Bool>) -> some View {
+    private func partSwitch(_ isOn: Binding<Bool>) -> some View {
         let enabledParts = [
             preferences.showLogoInMenuBar,
             preferences.showGaugeInMenuBar,
             preferences.showPercentInMenuBar,
         ].filter { $0 }.count
+        let locked = isOn.wrappedValue && enabledParts == 1
 
-        return Toggle(title, isOn: isOn)
-            .disabled(isOn.wrappedValue && enabledParts == 1)
+        return GlassSwitch(isOn: isOn, enabled: !locked)
             .onChange(of: isOn.wrappedValue) { _, _ in
                 store.iconPreferenceChanged()
             }
     }
+}
 
-    private func stepperRow(
-        value: Binding<Double>,
-        range: ClosedRange<Double>,
-        step: Double,
-        enabled: Bool,
-        text: String
-    ) -> some View {
-        Stepper(value: value, in: range, step: step) {
-            Text(text)
-                .foregroundStyle(enabled ? .primary : .tertiary)
+// --------------------------------------------------------------------- //
+
+/// An inset group whose rows are separated by hairlines rather than spacing —
+/// the shape macOS System Settings uses for a run of related switches.
+private struct DividedRows<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(spacing: 0) {
+            _VariadicView.Tree(Layout()) { content }
         }
-        .disabled(!enabled)
+        .padding(.horizontal, 14)
+        .background(
+            RoundedRectangle(cornerRadius: Glass.groupRadius, style: .continuous)
+                .fill(Color.white.opacity(0.07))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: Glass.groupRadius, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.11), lineWidth: 1)
+        )
+    }
+
+    private struct Layout: _VariadicView.UnaryViewRoot {
+        func body(children: _VariadicView.Children) -> some View {
+            let last = children.last?.id
+
+            ForEach(children) { child in
+                VStack(spacing: 0) {
+                    child.padding(.vertical, 11)
+                    if child.id != last {
+                        Rectangle()
+                            .fill(Color.white.opacity(0.09))
+                            .frame(height: 1)
+                    }
+                }
+            }
+        }
     }
 }

--- a/Sources/AIUsage/PanelView.swift
+++ b/Sources/AIUsage/PanelView.swift
@@ -90,7 +90,7 @@ private struct SettingsTab: View {
         VStack(alignment: .leading, spacing: 0) {
             // Capped and scrolled rather than allowed to grow: the whole point
             // of the tab is that the dropdown stays a predictable height.
-            ScrollView {
+            CappedScroll(maxHeight: Self.cap) {
                 VStack(alignment: .leading, spacing: 14) {
                     menuBarGroup
                     displayGroup
@@ -99,13 +99,20 @@ private struct SettingsTab: View {
                 }
                 .padding(EdgeInsets(top: 4, leading: 18, bottom: 14, trailing: 18))
             }
-            .scrollIndicators(.never)
-            .frame(maxHeight: 380)
 
             // Quit stays put instead of hiding at the bottom of the scroll.
             footer
                 .padding(EdgeInsets(top: 0, leading: 18, bottom: 18, trailing: 18))
         }
+    }
+
+    /// How tall the settings list is allowed to get before it starts scrolling.
+    /// Measured against the screen rather than fixed, so a large display shows
+    /// nearly the whole list while a laptop still leaves room for the header,
+    /// the footer and the menu bar the panel hangs from.
+    private static var cap: CGFloat {
+        let available = (NSScreen.main?.visibleFrame.height ?? 800) - 180
+        return min(640, max(320, available))
     }
 
     // ----------------------------------------------------------------- //
@@ -359,5 +366,86 @@ private struct DividedRows<Content: View>: View {
                 }
             }
         }
+    }
+}
+
+// --------------------------------------------------------------------- //
+
+/// A scroll area that admits it is one.
+///
+/// A hard cut at the cap is indistinguishable from the end of the list, and on
+/// a trackpad macOS keeps the scroller hidden until you are already scrolling —
+/// so the tab looked like it simply stopped after Refresh. The clipped edge now
+/// fades while there is more content past it, at whichever end is cut off, and
+/// firms up once you reach it. Below the cap it does not scroll and shows no
+/// fade at all.
+private struct CappedScroll<Content: View>: View {
+    let maxHeight: CGFloat
+    @ViewBuilder let content: Content
+
+    /// Top of the content within the scroll area: 0 at rest, negative once
+    /// scrolled. Paired with the two heights it says which edge is cut off.
+    @State private var offset: CGFloat = 0
+    @State private var contentHeight: CGFloat = 0
+    @State private var viewportHeight: CGFloat = 0
+
+    private let fade: CGFloat = 26
+    private let space = "capped-scroll"
+
+    private var hiddenAbove: Bool { viewportHeight > 0 && offset < -0.5 }
+    private var hiddenBelow: Bool { viewportHeight > 0 && contentHeight + offset - viewportHeight > 0.5 }
+
+    var body: some View {
+        ScrollView {
+            content.background(
+                GeometryReader { inner in
+                    Color.clear.preference(
+                        key: ReachKey.self,
+                        value: Reach(
+                            offset: inner.frame(in: .named(space)).minY,
+                            height: inner.size.height
+                        )
+                    )
+                }
+            )
+        }
+        .coordinateSpace(name: space)
+        .frame(maxHeight: maxHeight)
+        // An overlay is measured without being given a say in the layout, which
+        // is what keeps a short list sized to its content rather than the cap.
+        .overlay(
+            GeometryReader { viewport in
+                Color.clear
+                    .onAppear { viewportHeight = viewport.size.height }
+                    .onChange(of: viewport.size.height) { _, height in viewportHeight = height }
+            }
+        )
+        .onPreferenceChange(ReachKey.self) { reach in
+            offset = reach.offset
+            contentHeight = reach.height
+        }
+        .mask(
+            VStack(spacing: 0) {
+                LinearGradient(colors: [.black.opacity(0), .black], startPoint: .top, endPoint: .bottom)
+                    .frame(height: hiddenAbove ? fade : 0)
+                Rectangle()
+                LinearGradient(colors: [.black, .black.opacity(0)], startPoint: .top, endPoint: .bottom)
+                    .frame(height: hiddenBelow ? fade : 0)
+            }
+        )
+    }
+}
+
+/// Where the scrolled content currently sits. At file scope because a generic
+/// type cannot hold the static default a PreferenceKey needs.
+private struct Reach: Equatable {
+    var offset: CGFloat = 0
+    var height: CGFloat = 0
+}
+
+private struct ReachKey: PreferenceKey {
+    static let defaultValue = Reach()
+    static func reduce(value: inout Reach, nextValue: () -> Reach) {
+        value = nextValue()
     }
 }

--- a/Sources/AIUsage/PanelView.swift
+++ b/Sources/AIUsage/PanelView.swift
@@ -33,7 +33,7 @@ struct PanelView: View {
         // The same pane as the desktop card, which is what the design draws —
         // the dropdown had been getting a bare rectangle, so it was missing the
         // border and the lit top edge that make glass read as thick.
-        .glassPane(radius: Glass.panelRadius, saturation: 1.8, shadow: false)
+        .glassPane(radius: Glass.panelRadius, falloff: 0.033, tone: 1, shadow: false)
         .background(MenuWindowBackdrop())
         .environment(\.colorScheme, .dark)
         .onAppear { store.refreshIfStale(olderThan: 300) }

--- a/Sources/AIUsage/PanelView.swift
+++ b/Sources/AIUsage/PanelView.swift
@@ -296,6 +296,8 @@ private struct SettingsTab: View {
             GlassSlider(
                 value: slider,
                 range: range,
+                accessibilityLabel: title,
+                accessibilityValue: value,
                 step: step,
                 colors: colors,
                 enabled: isOn.wrappedValue

--- a/Sources/AIUsage/PanelView.swift
+++ b/Sources/AIUsage/PanelView.swift
@@ -30,11 +30,11 @@ struct PanelView: View {
             }
         }
         .frame(width: 430)
-        .background {
-            Rectangle()
-                .fill(.ultraThinMaterial)
-                .overlay(Rectangle().fill(Glass.sheen(top: 0.17)))
-        }
+        // The same pane as the desktop card, which is what the design draws —
+        // the dropdown had been getting a bare rectangle, so it was missing the
+        // border and the lit top edge that make glass read as thick.
+        .glassPane(radius: Glass.panelRadius, saturation: 1.8, shadow: false)
+        .background(MenuWindowBackdrop())
         .environment(\.colorScheme, .dark)
         .onAppear { store.refreshIfStale(olderThan: 300) }
     }
@@ -73,6 +73,55 @@ struct PanelView: View {
         if store.isRefreshing { return "Refreshing… · \(every)" }
         let stale = report.isStale ? " (stale)" : ""
         return "Updated \(report.updatedLabel)\(stale) · \(every)"
+    }
+}
+
+// --------------------------------------------------------------------- //
+
+/// Takes the menu bar window's own vibrant backdrop out of the way.
+///
+/// `MenuBarExtra(.window)` hands us a panel that already draws a material.
+/// Drawing our pane over it put two blurs in series, which is why the dropdown
+/// looked washed out beside the desktop card: a blur greys out what it samples,
+/// and doing it twice leaves the sheen nothing to lift. The design has one
+/// `backdrop-filter` per pane, so ours becomes the only one.
+///
+/// Best effort on purpose. An effect view that turns out to be an ancestor of
+/// our own content is left alone, so the worst case is the panel we already had
+/// rather than an invisible one.
+private struct MenuWindowBackdrop: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        let probe = NSView(frame: .zero)
+        // The view has no window until it is in the hierarchy, which is a
+        // runloop turn away from being made.
+        DispatchQueue.main.async { Self.clear(probe.window) }
+        return probe
+    }
+
+    func updateNSView(_ view: NSView, context: Context) {
+        DispatchQueue.main.async { Self.clear(view.window) }
+    }
+
+    private static func clear(_ window: NSWindow?) {
+        guard let window, let root = window.contentView else { return }
+        window.backgroundColor = .clear
+        window.isOpaque = false
+        hide(in: root)
+    }
+
+    private static func hide(in view: NSView) {
+        if let backdrop = view as? NSVisualEffectView {
+            if !holdsContent(backdrop) { backdrop.isHidden = true }
+            return
+        }
+        view.subviews.forEach(hide)
+    }
+
+    /// SwiftUI's hosting view is internal, so it is recognised by name. A miss
+    /// only means we leave a backdrop in place.
+    private static func holdsContent(_ view: NSView) -> Bool {
+        if String(describing: type(of: view)).contains("HostingView") { return true }
+        return view.subviews.contains(where: holdsContent)
     }
 }
 

--- a/Sources/AIUsage/PanelView.swift
+++ b/Sources/AIUsage/PanelView.swift
@@ -33,8 +33,7 @@ struct PanelView: View {
         // The same pane as the desktop card, which is what the design draws —
         // the dropdown had been getting a bare rectangle, so it was missing the
         // border and the lit top edge that make glass read as thick.
-        .glassPane(radius: Glass.panelRadius, falloff: 0.033, tone: 1, shadow: false)
-        .background(MenuWindowBackdrop())
+        .glassPane(radius: Glass.panelRadius, falloff: 0.033, tone: 1, border: 0.3, shadow: false)
         .environment(\.colorScheme, .dark)
         .onAppear { store.refreshIfStale(olderThan: 300) }
     }
@@ -77,53 +76,6 @@ struct PanelView: View {
 }
 
 // --------------------------------------------------------------------- //
-
-/// Takes the menu bar window's own vibrant backdrop out of the way.
-///
-/// `MenuBarExtra(.window)` hands us a panel that already draws a material.
-/// Drawing our pane over it put two blurs in series, which is why the dropdown
-/// looked washed out beside the desktop card: a blur greys out what it samples,
-/// and doing it twice leaves the sheen nothing to lift. The design has one
-/// `backdrop-filter` per pane, so ours becomes the only one.
-///
-/// Best effort on purpose. An effect view that turns out to be an ancestor of
-/// our own content is left alone, so the worst case is the panel we already had
-/// rather than an invisible one.
-private struct MenuWindowBackdrop: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSView {
-        let probe = NSView(frame: .zero)
-        // The view has no window until it is in the hierarchy, which is a
-        // runloop turn away from being made.
-        DispatchQueue.main.async { Self.clear(probe.window) }
-        return probe
-    }
-
-    func updateNSView(_ view: NSView, context: Context) {
-        DispatchQueue.main.async { Self.clear(view.window) }
-    }
-
-    private static func clear(_ window: NSWindow?) {
-        guard let window, let root = window.contentView else { return }
-        window.backgroundColor = .clear
-        window.isOpaque = false
-        hide(in: root)
-    }
-
-    private static func hide(in view: NSView) {
-        if let backdrop = view as? NSVisualEffectView {
-            if !holdsContent(backdrop) { backdrop.isHidden = true }
-            return
-        }
-        view.subviews.forEach(hide)
-    }
-
-    /// SwiftUI's hosting view is internal, so it is recognised by name. A miss
-    /// only means we leave a backdrop in place.
-    private static func holdsContent(_ view: NSView) -> Bool {
-        if String(describing: type(of: view)).contains("HostingView") { return true }
-        return view.subviews.contains(where: holdsContent)
-    }
-}
 
 // --------------------------------------------------------------------- //
 

--- a/Sources/AIUsage/PanelView.swift
+++ b/Sources/AIUsage/PanelView.swift
@@ -395,6 +395,17 @@ private struct CappedScroll<Content: View>: View {
     private var hiddenAbove: Bool { viewportHeight > 0 && offset < -0.5 }
     private var hiddenBelow: Bool { viewportHeight > 0 && contentHeight + offset - viewportHeight > 0.5 }
 
+    /// A ScrollView has no height of its own to offer, so `maxHeight` alone
+    /// leaves the window hosting it free to settle on something far shorter —
+    /// which is how the settings tab came out a third of its cap. Measuring the
+    /// content and asking for exactly what it needs, up to the cap, gives the
+    /// window a number it cannot argue with. Before the first measurement the
+    /// cap is the better guess: too tall corrects downwards on the same pass,
+    /// too short leaves the panel visibly stunted.
+    private var height: CGFloat {
+        contentHeight > 0 ? min(maxHeight, contentHeight) : maxHeight
+    }
+
     var body: some View {
         ScrollView {
             content.background(
@@ -410,9 +421,9 @@ private struct CappedScroll<Content: View>: View {
             )
         }
         .coordinateSpace(name: space)
-        .frame(maxHeight: maxHeight)
-        // An overlay is measured without being given a say in the layout, which
-        // is what keeps a short list sized to its content rather than the cap.
+        .frame(height: height)
+        // An overlay is measured without being given a say in the layout, so
+        // reading the viewport back cannot feed into the height above it.
         .overlay(
             GeometryReader { viewport in
                 Color.clear

--- a/Sources/AIUsage/PanelView.swift
+++ b/Sources/AIUsage/PanelView.swift
@@ -30,10 +30,11 @@ struct PanelView: View {
             }
         }
         .frame(width: 430)
-        // The same pane as the desktop card, which is what the design draws —
-        // the dropdown had been getting a bare rectangle, so it was missing the
-        // border and the lit top edge that make glass read as thick.
-        .glassPane(radius: Glass.panelRadius, falloff: 0.033, tone: 1, border: 0.3, shadow: false)
+        // The desktop card's pane exactly, rim included: the panel this hangs
+        // in is ours now, so its edge is the only one on screen.
+        // The shadow is the panel's own, as with the card: a SwiftUI one would
+        // be clipped by the window it is drawn inside.
+        .glassPane(radius: Glass.panelRadius, dim: 0.75, tone: 0.7, shadow: false)
         .environment(\.colorScheme, .dark)
         .onAppear { store.refreshIfStale(olderThan: 300) }
     }
@@ -74,8 +75,6 @@ struct PanelView: View {
         return "Updated \(report.updatedLabel)\(stale) · \(every)"
     }
 }
-
-// --------------------------------------------------------------------- //
 
 // --------------------------------------------------------------------- //
 

--- a/Sources/AIUsage/Report.swift
+++ b/Sources/AIUsage/Report.swift
@@ -88,6 +88,19 @@ struct Report: Codable, Equatable {
         Date().timeIntervalSince1970 - Double(updatedAt) > 2700
     }
 
+    /// How long ago the reading landed, in the card's second line. The absolute
+    /// clock beside it says *when*; this says whether it is worth trusting.
+    func ageLabel(now: Date = Date()) -> String {
+        let seconds = now.timeIntervalSince1970 - Double(updatedAt)
+        if updatedAt == 0 { return "never" }
+        if seconds < 90 { return "just now" }
+        let minutes = Int((seconds / 60).rounded())
+        if minutes < 60 { return "\(minutes) min ago" }
+        let hours = Int((seconds / 3600).rounded())
+        if hours < 24 { return "\(hours) hr ago" }
+        return "\(Int((seconds / 86400).rounded())) d ago"
+    }
+
     /// The windows worth watching, worst first.
     ///
     /// `fairShare` gives every provider a slot before any provider gets a

--- a/Sources/AIUsage/Report.swift
+++ b/Sources/AIUsage/Report.swift
@@ -128,7 +128,11 @@ struct Report: Codable, Equatable {
 
     /// Provider and window labels are each unique within a reading, but only
     /// together do they identify one row.
+    static func rowKey(provider: Provider, window: UsageWindow) -> String {
+        provider.name + "\u{1}" + window.label
+    }
+
     private static func key(_ pair: (provider: Provider, window: UsageWindow)) -> String {
-        pair.provider.name + "\u{1}" + pair.window.label
+        rowKey(provider: pair.provider, window: pair.window)
     }
 }

--- a/Sources/AIUsage/UsageCard.swift
+++ b/Sources/AIUsage/UsageCard.swift
@@ -14,16 +14,21 @@ struct RowMetrics {
     let labelSize: CGFloat
     let percentSize: CGFloat
     let resetSize: CGFloat
+    /// The provider mark beside the name, sized to the cap height of the name
+    /// rather than to its point size, so it reads as a sibling of the word.
+    let markSize: CGFloat
     let glows: Bool
 
     static let card = RowMetrics(
         label: 84, percent: 46, reset: 88, trackHeight: 10, gap: 12,
-        labelSize: 14, percentSize: 14, resetSize: 12, glows: true
+        labelSize: 14, percentSize: 14, resetSize: 12, markSize: 16, glows: true
     )
 
+    // The label column is wide enough for "spark week", which is the longest
+    // one any provider reports — at 66pt it came out as "spark w…".
     static let menu = RowMetrics(
-        label: 66, percent: 38, reset: 70, trackHeight: 8, gap: 10,
-        labelSize: 12, percentSize: 12, resetSize: 11, glows: false
+        label: 78, percent: 38, reset: 70, trackHeight: 8, gap: 10,
+        labelSize: 12, percentSize: 12, resetSize: 11, markSize: 14, glows: false
     )
 }
 
@@ -170,6 +175,11 @@ struct ProviderBlock: View {
 
         VStack(alignment: .leading, spacing: metrics.trackHeight == 10 ? 10 : 9) {
             HStack(alignment: .firstTextBaseline, spacing: 9) {
+                BrandMark(provider: provider.name, size: metrics.markSize)
+                    // Marks are centred on their own box, names sit on a
+                    // baseline; aligning the two by eye keeps the row level.
+                    .alignmentGuide(.firstTextBaseline) { $0[.bottom] - metrics.markSize * 0.14 }
+
                 Text(provider.name)
                     .font(.system(size: metrics.labelSize + 3, weight: .semibold))
                     .foregroundStyle(.white)
@@ -221,6 +231,35 @@ struct ProviderBlock: View {
         } else {
             text.foregroundStyle(Glass.ink(0.5))
         }
+    }
+}
+
+/// The provider mark beside its name, drawn from the same outline the menu bar
+/// uses. Monochrome and uniformly scaled, per the trademark note on
+/// `BrandGlyph` — pace colour stays on the track and the ring.
+struct BrandMark: View {
+    let provider: String
+    let size: CGFloat
+    var opacity: Double = 0.9
+
+    var body: some View {
+        Group {
+            if let outline = BrandGlyph.path(
+                for: provider,
+                fitting: NSSize(width: size, height: size),
+                flipped: false
+            ) {
+                // Even-odd, as the outline was parsed: the marks carry counters
+                // a nonzero fill would flood.
+                Path(outline.cgPath).fill(style: FillStyle(eoFill: true))
+            } else {
+                // The monogram the menu bar falls back to, at this size.
+                Text(String(provider.prefix(1)).uppercased())
+                    .font(.system(size: size * 0.78, weight: .semibold))
+            }
+        }
+        .foregroundStyle(Glass.ink(opacity))
+        .frame(width: size, height: size)
     }
 }
 

--- a/Sources/AIUsage/UsageCard.swift
+++ b/Sources/AIUsage/UsageCard.swift
@@ -1,120 +1,237 @@
 import SwiftUI
 
-/// The reading itself — header, then a block per provider. Shared verbatim by
-/// the menu bar dropdown and the desktop card so the two can never drift.
-struct UsageCard: View {
+/// The reading itself. Two densities of the same content: the roomy one the
+/// desktop card uses, and the tighter one that fits the dropdown's Usage tab.
+/// Both are driven by the same rows so the two can never drift apart.
+
+/// Column widths and type sizes — the only difference between the two.
+struct RowMetrics {
+    let label: CGFloat
+    let percent: CGFloat
+    let reset: CGFloat
+    let trackHeight: CGFloat
+    let gap: CGFloat
+    let labelSize: CGFloat
+    let percentSize: CGFloat
+    let resetSize: CGFloat
+    let glows: Bool
+
+    static let card = RowMetrics(
+        label: 84, percent: 46, reset: 88, trackHeight: 10, gap: 12,
+        labelSize: 14, percentSize: 14, resetSize: 12, glows: true
+    )
+
+    static let menu = RowMetrics(
+        label: 66, percent: 38, reset: 70, trackHeight: 8, gap: 10,
+        labelSize: 12, percentSize: 12, resetSize: 11, glows: false
+    )
+}
+
+// --------------------------------------------------------------------- //
+
+/// 1a — the free-standing glass card: summary line, hairline, then a block per
+/// provider with the word for how that provider on its own is doing.
+struct DesktopUsageCard: View {
     @EnvironmentObject private var store: UsageStore
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            header
+        let verdict = Pace.verdict(store.report)
+
+        VStack(alignment: .leading, spacing: 18) {
+            header(verdict)
+
+            Glass.hairline
 
             if let report = store.report {
                 ForEach(report.providers) { provider in
-                    ProviderView(provider: provider)
+                    ProviderBlock(provider: provider, metrics: .card)
                 }
             } else {
                 Text(store.isRefreshing ? "fetching…" : "no data yet")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
+                    .font(.system(size: 13))
+                    .foregroundStyle(Glass.ink(0.5))
             }
         }
     }
 
-    private var header: some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text("AI USAGE")
-                .font(.system(size: 10, weight: .medium))
-                .kerning(0.8)
-                .foregroundStyle(.tertiary)
-            Spacer()
-            Text(stamp)
-                .font(.system(size: 10))
-                .monospacedDigit()
-                .foregroundStyle(.tertiary)
-        }
-    }
+    private func header(_ verdict: Pace.Verdict) -> some View {
+        HStack(spacing: 14) {
+            PaceRing(percent: verdict.percent, color: verdict.color, size: 40)
 
-    private var stamp: String {
-        guard let report = store.report else { return "" }
-        if store.isRefreshing { return "refreshing…" }
-        return report.isStale ? "\(report.updatedLabel) (stale)" : report.updatedLabel
+            VStack(alignment: .leading, spacing: 2) {
+                Text("AI USAGE")
+                    .font(.system(size: 11, weight: .regular))
+                    .kerning(1.4)
+                    .foregroundStyle(Glass.ink(0.5))
+                Text(verdict.line)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(verdict.hot ? Color(red: 1, green: 0.788, blue: 0.788) : .white)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 8)
+
+            VStack(alignment: .trailing, spacing: 3) {
+                Text(store.report?.updatedLabel ?? "--:--")
+                    .font(.system(size: 13))
+                    .monospacedDigit()
+                    .foregroundStyle(Glass.ink(0.7))
+                Text(store.isRefreshing ? "refreshing…" : (store.report?.ageLabel() ?? "never"))
+                    .font(.system(size: 11))
+                    .foregroundStyle(Glass.ink(0.4))
+            }
+            .fixedSize()
+        }
     }
 }
 
-struct ProviderView: View {
-    let provider: Provider
+// --------------------------------------------------------------------- //
+
+/// 1b — the Usage tab: one summary pill, then the same rows a size down.
+struct MenuUsageView: View {
+    @EnvironmentObject private var store: UsageStore
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 5) {
-            HStack(alignment: .firstTextBaseline) {
+        let verdict = Pace.verdict(store.report)
+
+        VStack(alignment: .leading, spacing: 16) {
+            summary(verdict)
+
+            if let report = store.report {
+                VStack(alignment: .leading, spacing: 11) {
+                    ForEach(report.providers) { provider in
+                        ProviderBlock(provider: provider, metrics: .menu, showsNote: false)
+                    }
+                }
+            } else {
+                Text(store.isRefreshing ? "fetching…" : "no data yet")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Glass.ink(0.5))
+            }
+        }
+    }
+
+    private func summary(_ verdict: Pace.Verdict) -> some View {
+        HStack(spacing: 12) {
+            PaceRing(percent: verdict.percent, color: verdict.color, size: 36)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(verdict.headline)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.white)
+                Text(verdict.detail)
+                    .font(.system(size: 12))
+                    .foregroundStyle(Glass.ink(0.5))
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 14)
+        .background(
+            RoundedRectangle(cornerRadius: Glass.groupRadius, style: .continuous)
+                .fill(Color.white.opacity(0.09))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: Glass.groupRadius, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
+        )
+    }
+}
+
+// --------------------------------------------------------------------- //
+
+struct ProviderBlock: View {
+    let provider: Provider
+    let metrics: RowMetrics
+    var showsNote: Bool = true
+
+    var body: some View {
+        let note = Pace.note(provider)
+
+        VStack(alignment: .leading, spacing: metrics.trackHeight == 10 ? 10 : 9) {
+            HStack(alignment: .firstTextBaseline, spacing: 9) {
                 Text(provider.name)
-                    .font(.system(size: 12, weight: .semibold))
-                Spacer()
-                Text((provider.plan ?? "").uppercased())
-                    .font(.system(size: 9, weight: .medium))
-                    .kerning(0.6)
-                    .foregroundStyle(.tertiary)
+                    .font(.system(size: metrics.labelSize + 3, weight: .semibold))
+                    .foregroundStyle(.white)
+
+                if let plan = provider.plan, !plan.isEmpty {
+                    planBadge(plan)
+                }
+
+                Spacer(minLength: 6)
+
+                if showsNote {
+                    Text(note.text)
+                        .font(.system(size: 12))
+                        .foregroundStyle(note.color)
+                }
             }
 
             if provider.ok {
                 ForEach(provider.windows) { window in
-                    WindowRow(window: window)
+                    UsageRow(window: window, metrics: metrics)
                 }
             } else {
                 Text(provider.error ?? "unavailable")
-                    .font(.system(size: 10))
+                    .font(.system(size: metrics.resetSize))
                     .foregroundStyle(Pace.bad)
             }
         }
     }
-}
 
-struct WindowRow: View {
-    let window: UsageWindow
+    @ViewBuilder
+    private func planBadge(_ plan: String) -> some View {
+        let text = Text(plan.uppercased())
+            .font(.system(size: metrics.labelSize == 14 ? 11 : 10, weight: .semibold))
+            .kerning(1)
 
-    var body: some View {
-        HStack(spacing: 8) {
-            Text(window.label)
-                .font(.system(size: 10))
-                .foregroundStyle(.secondary)
-                .frame(width: 62, alignment: .leading)
-
-            track
-
-            Text("\(Int(window.percent.rounded()))%")
-                .font(.system(size: 10))
-                .monospacedDigit()
-                .frame(width: 30, alignment: .trailing)
-
-            Text(Pace.resetLabel(window.resetsAt))
-                .font(.system(size: 9))
-                .monospacedDigit()
-                .foregroundStyle(.tertiary)
-                .frame(width: 68, alignment: .trailing)
+        if showsNote {
+            text
+                .foregroundStyle(Glass.ink(0.72))
+                .padding(.horizontal, 7)
+                .padding(.vertical, 2)
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(Color.white.opacity(0.14))
+                )
+        } else {
+            text.foregroundStyle(Glass.ink(0.5))
         }
     }
+}
 
-    private var track: some View {
-        GeometryReader { geometry in
-            let width = geometry.size.width
-            ZStack(alignment: .leading) {
-                Capsule()
-                    .fill(.primary.opacity(0.09))
+struct UsageRow: View {
+    let window: UsageWindow
+    let metrics: RowMetrics
 
-                Capsule()
-                    .fill(Pace.color(window))
-                    .frame(width: width * min(100, max(2, window.percent)) / 100)
+    var body: some View {
+        HStack(spacing: metrics.gap) {
+            Text(window.label)
+                .font(.system(size: metrics.labelSize))
+                .foregroundStyle(Glass.ink(0.6))
+                .frame(width: metrics.label, alignment: .leading)
 
-                // Where usage *should* be if spent evenly across the window.
-                if let elapsed = Pace.elapsedPercent(window) {
-                    Rectangle()
-                        .fill(.primary.opacity(0.55))
-                        .frame(width: 1)
-                        .offset(x: width * elapsed / 100)
-                }
-            }
+            UsageTrack(
+                percent: window.percent,
+                elapsed: Pace.elapsedPercent(window),
+                palette: Pace.palette(window),
+                height: metrics.trackHeight,
+                glows: metrics.glows
+            )
+
+            Text("\(Int(window.percent.rounded()))%")
+                .font(.system(size: metrics.percentSize, weight: .semibold))
+                .monospacedDigit()
+                .foregroundStyle(Glass.ink(window.percent < 0.5 ? 0.55 : 1))
+                .frame(width: metrics.percent, alignment: .trailing)
+
+            Text(Pace.resetLabel(window.resetsAt))
+                .font(.system(size: metrics.resetSize))
+                .monospacedDigit()
+                .foregroundStyle(Glass.ink(0.45))
+                .frame(width: metrics.reset, alignment: .trailing)
         }
-        .frame(height: 6)
     }
 }

--- a/Sources/AIUsage/UsageCard.swift
+++ b/Sources/AIUsage/UsageCard.swift
@@ -44,7 +44,7 @@ struct DesktopUsageCard: View {
 
             if let report = store.report {
                 ForEach(report.providers) { provider in
-                    ProviderBlock(provider: provider, metrics: .card)
+                    ProviderBlock(provider: provider, metrics: .card, worstRow: verdict.rowKey)
                 }
             } else {
                 Text(store.isRefreshing ? "fetching…" : "no data yet")
@@ -56,10 +56,15 @@ struct DesktopUsageCard: View {
 
     private func header(_ verdict: Pace.Verdict) -> some View {
         HStack(spacing: 14) {
-            PaceRing(percent: verdict.percent, color: verdict.color, size: 40)
+            PaceRing(
+                percent: verdict.percent,
+                color: verdict.color,
+                elapsed: verdict.elapsed,
+                size: 40
+            )
 
             VStack(alignment: .leading, spacing: 2) {
-                Text("AI USAGE")
+                Text(verdict.source.map { "WORST — \($0.uppercased())" } ?? "AI USAGE")
                     .font(.system(size: 11, weight: .regular))
                     .kerning(1.4)
                     .foregroundStyle(Glass.ink(0.5))
@@ -101,7 +106,12 @@ struct MenuUsageView: View {
             if let report = store.report {
                 VStack(alignment: .leading, spacing: 11) {
                     ForEach(report.providers) { provider in
-                        ProviderBlock(provider: provider, metrics: .menu, showsNote: false)
+                        ProviderBlock(
+                            provider: provider,
+                            metrics: .menu,
+                            showsNote: false,
+                            worstRow: verdict.rowKey
+                        )
                     }
                 }
             } else {
@@ -114,7 +124,12 @@ struct MenuUsageView: View {
 
     private func summary(_ verdict: Pace.Verdict) -> some View {
         HStack(spacing: 12) {
-            PaceRing(percent: verdict.percent, color: verdict.color, size: 36)
+            PaceRing(
+                percent: verdict.percent,
+                color: verdict.color,
+                elapsed: verdict.elapsed,
+                size: 36
+            )
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(verdict.headline)
@@ -146,6 +161,9 @@ struct ProviderBlock: View {
     let provider: Provider
     let metrics: RowMetrics
     var showsNote: Bool = true
+    /// The row the summary above is speaking for, marked here so the reader can
+    /// trace the ring back to the window it came from.
+    var worstRow: String? = nil
 
     var body: some View {
         let note = Pace.note(provider)
@@ -171,7 +189,11 @@ struct ProviderBlock: View {
 
             if provider.ok {
                 ForEach(provider.windows) { window in
-                    UsageRow(window: window, metrics: metrics)
+                    UsageRow(
+                        window: window,
+                        metrics: metrics,
+                        isWorst: worstRow == Report.rowKey(provider: provider, window: window)
+                    )
                 }
             } else {
                 Text(provider.error ?? "unavailable")
@@ -205,13 +227,22 @@ struct ProviderBlock: View {
 struct UsageRow: View {
     let window: UsageWindow
     let metrics: RowMetrics
+    var isWorst: Bool = false
 
     var body: some View {
         HStack(spacing: metrics.gap) {
-            Text(window.label)
-                .font(.system(size: metrics.labelSize))
-                .foregroundStyle(Glass.ink(0.6))
-                .frame(width: metrics.label, alignment: .leading)
+            // The dot sits in a gutter every row pays for, so marking a row
+            // moves nothing.
+            HStack(spacing: 5) {
+                Circle()
+                    .fill(isWorst ? Pace.color(window) : .clear)
+                    .frame(width: 4, height: 4)
+
+                Text(window.label)
+                    .font(.system(size: metrics.labelSize, weight: isWorst ? .semibold : .regular))
+                    .foregroundStyle(Glass.ink(isWorst ? 0.95 : 0.6))
+            }
+            .frame(width: metrics.label, alignment: .leading)
 
             UsageTrack(
                 percent: window.percent,


### PR DESCRIPTION
Rebuilds both readings on one glass vocabulary (`Glass.swift`): the desktop card and the menu bar dropdown now share the same pane, tracks, ring and controls, settings moves into its own tab so opening it can no longer push the reading off the bottom of the screen, the summary names the worst window and judges it against the even-burn mark, and the provider logos already used in the menu bar now sit beside their names in both surfaces.

The dropdown also stops being a `MenuBarExtra(.window)` and becomes an app-owned `NSStatusItem` plus borderless `NSPanel`, the way the desktop card already was: that window draws a hairline *over* the content it hosts, which a 3pt red test stroke confirmed — the outermost column came back white-over-red at 173 luminance against a pane of 50 — so no rim of ours could ever cover it. With our own panel the pane's own rim is the only edge left, measuring 109 over a 51 interior against the card's 161 over 128.

Also adds two project skills under `.agents/skills` (symlinked into `.claude/skills`): the pixel-measurement loop that produced those numbers, so a claim about a rendered edge gets measured rather than guessed, and a companion on writing skills. README is updated to match the new dropdown, card and settings groups.

Verified by driving the installed app: dropdown opens under the item, both tabs click through and scroll, click-outside and click-item both close it, `./test.sh` passes.