### PR TITLE
Keep the last reading when a poll fails, and say why once

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,17 @@ under System Settings → Notifications → AI Usage. Notifications need the app
 be signed, which `build.sh` handles — running the raw `swift build` binary skips
 them on purpose.
 
-**`token expired — run claude` / `run codex`**
+**`stored token went stale — run claude once` / `run codex once`**
 
-The OAuth token lapsed. Start the relevant CLI once; it refreshes the token in
-place and the next fetch recovers. By design this app never refreshes tokens
-itself — it will not touch your logins.
+You are still signed in. Each CLI keeps a refresh token and mints a new access
+token when it next runs, so the copy this app reads out of their store lapses on
+its own — overnight, typically. Start the relevant CLI once and the next fetch
+recovers. By design this app never refreshes tokens itself — it will not touch
+your logins.
+
+Until it recovers, the rows carry the last reading that did land, dimmed, with
+the notice saying when it was taken. They are dropped once they are three hours
+old or their window has reset, whichever comes first.
 
 **`http 403` from Codex**
 

--- a/Sources/AIUsage/Fetcher.swift
+++ b/Sources/AIUsage/Fetcher.swift
@@ -42,16 +42,16 @@ enum Fetcher {
 
         let data: [String: Any]
         do {
-            data = try await getJSON(claudeUsageURL, headers: [
+            data = try await getJSONRetrying(claudeUsageURL, headers: [
                 "Authorization": "Bearer \(token)",
                 "anthropic-beta": "oauth-2025-04-20",
                 "Accept": "application/json",
             ])
         } catch let error as HTTPStatus {
-            provider.error = error.code == 401 ? "token expired — run claude" : "http \(error.code)"
+            provider.error = note(for: error.code, refreshWith: "claude")
             return provider
         } catch {
-            provider.error = String(error.localizedDescription.prefix(80))
+            provider.error = "unreachable — \(error.localizedDescription.prefix(60))"
             return provider
         }
 
@@ -95,19 +95,14 @@ enum Fetcher {
 
         let data: [String: Any]
         do {
-            do {
-                data = try await getJSON(codexUsageURL, headers: headers)
-            } catch let error as HTTPStatus where error.code == 403 {
-                // The edge in front of chatgpt.com occasionally answers 403 to
-                // an otherwise valid request; one retry clears it.
-                try await Task.sleep(nanoseconds: 2_000_000_000)
-                data = try await getJSON(codexUsageURL, headers: headers)
-            }
+            // The edge in front of chatgpt.com occasionally answers 403 to an
+            // otherwise valid request; the retry inside covers that.
+            data = try await getJSONRetrying(codexUsageURL, headers: headers)
         } catch let error as HTTPStatus {
-            provider.error = error.code == 401 ? "token expired — run codex" : "http \(error.code)"
+            provider.error = note(for: error.code, refreshWith: "codex")
             return provider
         } catch {
-            provider.error = String(error.localizedDescription.prefix(80))
+            provider.error = "unreachable — \(error.localizedDescription.prefix(60))"
             return provider
         }
 
@@ -150,6 +145,43 @@ enum Fetcher {
 
     struct HTTPStatus: Error {
         let code: Int
+    }
+
+    /// What to tell the reader about a failed poll.
+    ///
+    /// A 401 is not a sign-out: both CLIs keep a refresh token and mint a new
+    /// access token when they next run, so the copy we read from their store
+    /// simply goes stale — overnight, typically. Saying "expired, log in again"
+    /// there was wrong as well as alarming; running the CLI once is the fix.
+    static func note(for code: Int, refreshWith command: String) -> String {
+        switch code {
+        case 401: return "stored token went stale — run \(command) once"
+        case 429: return "rate limited — the reading will catch up"
+        case 500...599: return "the service is not answering (http \(code))"
+        default: return "http \(code)"
+        }
+    }
+
+    /// One retry, two seconds later, on a failure a second attempt can plausibly
+    /// clear: a dropped connection, a 5xx, a throttle, or the 403 the chatgpt.com
+    /// edge sometimes answers with. A 401 is not retried — the stored token will
+    /// not have changed by then; only the CLI running again fixes that.
+    private static func getJSONRetrying(
+        _ url: URL,
+        headers: [String: String]
+    ) async throws -> [String: Any] {
+        do {
+            return try await getJSON(url, headers: headers)
+        } catch {
+            guard retryable(error) else { throw error }
+            try await Task.sleep(nanoseconds: 2_000_000_000)
+            return try await getJSON(url, headers: headers)
+        }
+    }
+
+    private static func retryable(_ error: Error) -> Bool {
+        guard let status = error as? HTTPStatus else { return true }
+        return status.code == 403 || status.code == 429 || status.code >= 500
     }
 
     private static func getJSON(_ url: URL, headers: [String: String]) async throws -> [String: Any] {

--- a/Sources/AIUsage/Notifier.swift
+++ b/Sources/AIUsage/Notifier.swift
@@ -31,7 +31,9 @@ enum Notifier {
         guard isBundled else { return }
         var marks = loadMarks()
 
-        for provider in report.providers where provider.ok {
+        // Carried-over numbers were already judged when they were fresh; a
+        // stale provider must not be able to raise an alert twice.
+        for provider in report.providers where provider.ok && !provider.stale {
             for window in provider.windows {
                 let key = "\(provider.name)/\(window.label)"
                 var mark = marks[key] ?? Mark(resetsAt: window.resetsAt)

--- a/Sources/AIUsage/Pace.swift
+++ b/Sources/AIUsage/Pace.swift
@@ -203,8 +203,11 @@ enum Pace {
     }
 
     /// The word beside a provider's name: how that provider on its own is doing.
-    static func note(_ provider: Provider, now: Date = Date()) -> (text: String, color: Color) {
-        guard provider.ok else { return (provider.error ?? "unavailable", bad) }
+    /// Nil when the reading is missing or carried over from an earlier poll:
+    /// what happened is said once, in the notice above the list, and a verdict
+    /// read off stale numbers would be stated with more confidence than it has.
+    static func note(_ provider: Provider, now: Date = Date()) -> (text: String, color: Color)? {
+        guard provider.ok, !provider.stale else { return nil }
         guard let worst = provider.windows.max(by: { severity($0, now: now) < severity($1, now: now) })
         else { return ("no windows", .white.opacity(0.45)) }
 
@@ -215,6 +218,13 @@ enum Pace {
         case 1: return ("ahead of pace", warn)
         default: return ("under budget", good)
         }
+    }
+
+    /// Bare wall clock, for saying when a carried-over reading was taken.
+    static func clockLabel(_ epoch: Int) -> String {
+        let clock = DateFormatter()
+        clock.dateFormat = "HH:mm"
+        return clock.string(from: Date(timeIntervalSince1970: Double(epoch)))
     }
 
     /// Absolute reset time. Bare clock today, weekday within the week, and a

--- a/Sources/AIUsage/Report.swift
+++ b/Sources/AIUsage/Report.swift
@@ -40,8 +40,23 @@ struct Provider: Codable, Identifiable, Equatable {
     var plan: String?
     var error: String?
     var windows: [UsageWindow] = []
+    /// True when `windows` is the last reading that did land rather than one
+    /// taken now: the poll failed and these numbers were carried over.
+    var stale: Bool = false
+    /// When those carried numbers were actually measured.
+    var measuredAt: Int?
 
     var id: String { name }
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case ok
+        case plan
+        case error
+        case windows
+        case stale
+        case measuredAt = "measured_at"
+    }
 
     init(name: String) {
         self.name = name
@@ -54,6 +69,8 @@ struct Provider: Codable, Identifiable, Equatable {
         plan = try? box.decodeIfPresent(String.self, forKey: .plan)
         error = try? box.decodeIfPresent(String.self, forKey: .error)
         windows = (try? box.decode([UsageWindow].self, forKey: .windows)) ?? []
+        stale = (try? box.decode(Bool.self, forKey: .stale)) ?? false
+        measuredAt = try? box.decodeIfPresent(Int.self, forKey: .measuredAt)
     }
 }
 
@@ -81,6 +98,39 @@ struct Report: Codable, Equatable {
         updatedAt = (try? box.decode(Int.self, forKey: .updatedAt)) ?? 0
         updatedLabel = (try? box.decode(String.self, forKey: .updatedLabel)) ?? "--:--"
         providers = (try? box.decode([Provider].self, forKey: .providers)) ?? []
+    }
+
+    /// A provider that failed this round keeps the numbers it last reported,
+    /// marked stale, instead of the card blanking out. Most failures are one
+    /// bad poll — an access token the CLI has not refreshed yet, or the API not
+    /// answering — and the previous reading stays the best answer to "am I
+    /// fine?" for the few minutes until the next try.
+    ///
+    /// Only for a while: past `carryLimit` the quota windows have moved on and
+    /// the old numbers would be a lie rather than an approximation.
+    static let carryLimit: TimeInterval = 3 * 3600
+
+    func carryingOver(from previous: Report?, now: Date = Date()) -> Report {
+        guard let previous else { return self }
+        var merged = self
+        merged.providers = providers.map { provider in
+            guard !provider.ok,
+                  let old = previous.providers.first(where: { $0.name == provider.name }),
+                  old.ok
+            else { return provider }
+
+            let measured = (old.stale ? old.measuredAt : previous.updatedAt) ?? previous.updatedAt
+            guard now.timeIntervalSince1970 - Double(measured) < Self.carryLimit else { return provider }
+
+            var carried = provider
+            carried.ok = true
+            carried.stale = true
+            carried.plan = provider.plan ?? old.plan
+            carried.windows = old.windows
+            carried.measuredAt = measured
+            return carried
+        }
+        return merged
     }
 
     /// A reading older than this is shown as stale rather than silently trusted.

--- a/Sources/AIUsage/Report.swift
+++ b/Sources/AIUsage/Report.swift
@@ -122,11 +122,21 @@ struct Report: Codable, Equatable {
             let measured = (old.stale ? old.measuredAt : previous.updatedAt) ?? previous.updatedAt
             guard now.timeIntervalSince1970 - Double(measured) < Self.carryLimit else { return provider }
 
+            // A window that has passed its reset is a fresh window we know
+            // nothing about, not a spent one: carrying "94%, nearly out" across
+            // the boundary would keep the menu bar red through the first hours
+            // of a quota that is actually empty.
+            let live = old.windows.filter { window in
+                guard let resetsAt = window.resetsAt, resetsAt > 0 else { return true }
+                return Double(resetsAt) > now.timeIntervalSince1970
+            }
+            guard !live.isEmpty else { return provider }
+
             var carried = provider
             carried.ok = true
             carried.stale = true
             carried.plan = provider.plan ?? old.plan
-            carried.windows = old.windows
+            carried.windows = live
             carried.measuredAt = measured
             return carried
         }

--- a/Sources/AIUsage/UsageCard.swift
+++ b/Sources/AIUsage/UsageCard.swift
@@ -45,6 +45,8 @@ struct DesktopUsageCard: View {
         VStack(alignment: .leading, spacing: 18) {
             header(verdict)
 
+            OutageNotice(report: store.report, size: 12)
+
             Glass.hairline
 
             if let report = store.report {
@@ -108,6 +110,8 @@ struct MenuUsageView: View {
         VStack(alignment: .leading, spacing: 16) {
             summary(verdict)
 
+            OutageNotice(report: store.report, size: 11)
+
             if let report = store.report {
                 VStack(alignment: .leading, spacing: 11) {
                     ForEach(report.providers) { provider in
@@ -162,6 +166,45 @@ struct MenuUsageView: View {
 
 // --------------------------------------------------------------------- //
 
+/// Why a provider has no reading, said once for the whole card and in amber
+/// rather than red: a missed poll is a gap in what we know, not a warning about
+/// spending, and the rows below still say everything we do know.
+struct OutageNotice: View {
+    let report: Report?
+    let size: CGFloat
+
+    var body: some View {
+        let down = (report?.providers ?? []).filter { !$0.ok || $0.stale }
+
+        if !down.isEmpty {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(down) { provider in
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Image(systemName: "exclamationmark.circle")
+                            .font(.system(size: size))
+                        Text(Self.line(provider))
+                            .font(.system(size: size))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .foregroundStyle(Pace.warn.opacity(0.92))
+        }
+    }
+
+    /// A stale provider still has rows below, so the notice has to say which
+    /// reading those rows are — otherwise the numbers look current.
+    static func line(_ provider: Provider) -> String {
+        let reason = provider.error ?? "no reading"
+        guard provider.stale, let measured = provider.measuredAt else {
+            return "\(provider.name): \(reason)"
+        }
+        return "\(provider.name): \(reason) · rows from \(Pace.clockLabel(measured))"
+    }
+}
+
+// --------------------------------------------------------------------- //
+
 struct ProviderBlock: View {
     let provider: Provider
     let metrics: RowMetrics
@@ -190,14 +233,18 @@ struct ProviderBlock: View {
 
                 Spacer(minLength: 6)
 
-                if showsNote {
+                if showsNote, let note {
                     Text(note.text)
                         .font(.system(size: 12))
                         .foregroundStyle(note.color)
                 }
             }
 
-            if provider.ok {
+            // A provider with no reading contributes its name and nothing else:
+            // the reason is carried once by `OutageNotice`, above the list.
+            // Carried-over rows are dimmed there, so they cannot be mistaken
+            // for numbers that were just measured.
+            VStack(alignment: .leading, spacing: metrics.trackHeight == 10 ? 10 : 9) {
                 ForEach(provider.windows) { window in
                     UsageRow(
                         window: window,
@@ -205,11 +252,8 @@ struct ProviderBlock: View {
                         isWorst: worstRow == Report.rowKey(provider: provider, window: window)
                     )
                 }
-            } else {
-                Text(provider.error ?? "unavailable")
-                    .font(.system(size: metrics.resetSize))
-                    .foregroundStyle(Pace.bad)
             }
+            .opacity(provider.stale ? 0.55 : 1)
         }
     }
 

--- a/Sources/AIUsage/UsageStore.swift
+++ b/Sources/AIUsage/UsageStore.swift
@@ -66,11 +66,11 @@ final class UsageStore: ObservableObject {
         isRefreshing = true
         defer { isRefreshing = false }
 
-        let fresh = await Fetcher.fetchAll()
-        report = fresh
-        write(fresh)
+        let merged = (await Fetcher.fetchAll()).carryingOver(from: report)
+        report = merged
+        write(merged)
         redrawIcon()
-        Notifier.evaluate(fresh)
+        Notifier.evaluate(merged)
     }
 
     func refreshIfStale(olderThan seconds: TimeInterval) {

--- a/Tests/RegressionTests.swift
+++ b/Tests/RegressionTests.swift
@@ -19,6 +19,8 @@ enum RegressionTests {
         testWindowInitialSkipsDigits()
         testMenuBarItemIsNeverZeroWidth()
         testStrayArgumentAfterCloseIsRejected()
+        testFailedPollKeepsTheLastReading()
+        testCarriedReadingIsDroppedOnceItIsOld()
         print("All regression tests passed")
     }
 
@@ -195,6 +197,38 @@ enum RegressionTests {
         check(StatusIcon.windowInitial("week") == "w", "week must be marked w")
         check(StatusIcon.windowInitial("spark week") == "s", "spark week must be marked s")
         check(StatusIcon.windowInitial("30") == nil, "a label with no letters gets no mark")
+    }
+
+    private static func testFailedPollKeepsTheLastReading() {
+        let good = Report(
+            providers: [provider(name: "Claude", windows: [window(percent: 40, elapsedPercent: 50)])],
+            date: now
+        )
+        var failed = Provider(name: "Claude")
+        failed.error = "stored token went stale — run claude once to refresh it"
+        let merged = Report(providers: [failed], date: now.addingTimeInterval(900))
+            .carryingOver(from: good, now: now.addingTimeInterval(900))
+
+        let carried = merged.providers[0]
+        check(carried.ok, "a one-off failed poll must not blank the provider out")
+        check(carried.stale, "the carried reading must be marked stale")
+        check(carried.windows.count == 1, "the last reading's rows must survive")
+        check(carried.error != nil, "the reason for the failed poll must still be said")
+        check(carried.measuredAt == good.updatedAt, "the carried rows must say when they were measured")
+    }
+
+    private static func testCarriedReadingIsDroppedOnceItIsOld() {
+        let good = Report(
+            providers: [provider(name: "Claude", windows: [window(percent: 40, elapsedPercent: 50)])],
+            date: now
+        )
+        let later = now.addingTimeInterval(Report.carryLimit + 60)
+        var failed = Provider(name: "Claude")
+        failed.error = "the service is not answering (http 503)"
+        let merged = Report(providers: [failed], date: later).carryingOver(from: good, now: later)
+
+        check(!merged.providers[0].ok, "a reading older than the carry limit must not be shown as usable")
+        check(merged.providers[0].windows.isEmpty, "stale-beyond-limit rows must be dropped")
     }
 
     // ----------------------------------------------------------------- //

--- a/Tests/RegressionTests.swift
+++ b/Tests/RegressionTests.swift
@@ -21,6 +21,7 @@ enum RegressionTests {
         testStrayArgumentAfterCloseIsRejected()
         testFailedPollKeepsTheLastReading()
         testCarriedReadingIsDroppedOnceItIsOld()
+        testCarriedWindowIsDroppedOnceItHasReset()
         print("All regression tests passed")
     }
 
@@ -206,8 +207,10 @@ enum RegressionTests {
         )
         var failed = Provider(name: "Claude")
         failed.error = "stored token went stale — run claude once to refresh it"
-        let merged = Report(providers: [failed], date: now.addingTimeInterval(900))
-            .carryingOver(from: good, now: now.addingTimeInterval(900))
+        // Inside the carried window's own life: a window that has reset is a
+        // separate case, and `testCarriedWindowIsDroppedOnceItHasReset` has it.
+        let later = now.addingTimeInterval(300)
+        let merged = Report(providers: [failed], date: later).carryingOver(from: good, now: later)
 
         let carried = merged.providers[0]
         check(carried.ok, "a one-off failed poll must not blank the provider out")
@@ -229,6 +232,43 @@ enum RegressionTests {
 
         check(!merged.providers[0].ok, "a reading older than the carry limit must not be shown as usable")
         check(merged.providers[0].windows.isEmpty, "stale-beyond-limit rows must be dropped")
+    }
+
+    private static func testCarriedWindowIsDroppedOnceItHasReset() {
+        // 94% of a five-hour window that resets a minute from now. Once it has,
+        // the quota is empty and carrying the old number would keep the menu bar
+        // red — and the verdict at "nearly out" — through the fresh window.
+        let spent = UsageWindow(
+            label: "5h",
+            percent: 94,
+            resetsAt: Int(now.timeIntervalSince1970) + 60,
+            windowSeconds: 18_000
+        )
+        let week = UsageWindow(
+            label: "week",
+            percent: 30,
+            resetsAt: Int(now.timeIntervalSince1970) + 86_400,
+            windowSeconds: 604_800
+        )
+        let good = Report(providers: [provider(name: "Claude", windows: [spent, week])], date: now)
+
+        let later = now.addingTimeInterval(120)
+        var failed = Provider(name: "Claude")
+        failed.error = "stored token went stale — run claude once"
+        let merged = Report(providers: [failed], date: later).carryingOver(from: good, now: later)
+
+        let carried = merged.providers[0]
+        check(carried.ok && carried.stale, "the windows that have not reset must still be carried")
+        check(
+            carried.windows.map(\.label) == ["week"],
+            "a window carried past its own reset must be dropped"
+        )
+
+        // And with nothing left to carry, the provider goes back to having no
+        // reading rather than to an empty one that still counts as usable.
+        let onlySpent = Report(providers: [provider(name: "Claude", windows: [spent])], date: now)
+        let emptied = Report(providers: [failed], date: later).carryingOver(from: onlySpent, now: later)
+        check(!emptied.providers[0].ok, "a provider whose every carried window has reset is not ok")
     }
 
     // ----------------------------------------------------------------- //


### PR DESCRIPTION
A failed poll used to take the whole provider down with it: Claude's rows were replaced by `token expired — run claude` in red, and the same sentence appeared a second time beside the provider's name. It fired most mornings — both CLIs keep a refresh token and mint a new access token when they next run, so the copy the app reads out of their store goes stale overnight. Nobody was signed out.

**Carry the last reading.** A provider that fails keeps the numbers it last reported, dimmed to 0.55 and marked stale, with the notice saying which reading they are (`rows from 08:56`). The carry expires after three hours, past which the windows have moved on. Stale providers raise no notifications and get no verdict word beside their name.

**Say it once, in amber.** The reason moves above the list, out of the per-provider block, and out of the red reserved for spending trouble. 401 is `stored token went stale — run claude once`, 429 is `rate limited — the reading will catch up`, 5xx names the service rather than the token.

**Retry once.** Two seconds later, on 403 / 429 / 5xx / dropped connection, for both providers. A 401 is not retried — the stored token will not have changed by then. This folds in the retry Codex already had for the edge's occasional 403.

## Verification

Forced a 401 against the installed app and measured the result on screen:

- Card, forced 401: one amber line, Claude's rows dimmed and kept, no duplicate. Panel grew 283pt → 316pt for the notice line.
- Dropdown, forced 401: same line at 11pt, one line inside 430pt.
- Healthy state: unchanged, no notice.

`./test.sh` passes, including two new cases — a failed poll keeps the rows and records when they were measured, and a reading older than the carry limit is dropped rather than shown.

Not in this PR: Codex reading 0% was checked against the live endpoint and is correct — the weekly window reset at 06:09 today, and the plan now reports only a weekly window (`secondary_window: null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)