### PR TITLE
Brand app as Tokens on Track

### DIFF
--- a/.agents/skills/glass-ui-changes/SKILL.md
+++ b/.agents/skills/glass-ui-changes/SKILL.md
@@ -35,13 +35,13 @@ opens at a negative x and no screenshot will ever contain it. Install and drive
 the real app:
 
 ```sh
-swift build && ./build.sh --install    # relaunches /Applications/AI Usage.app
+swift build && ./build.sh --install    # relaunches /Applications/Tokens on Track.app
 ```
 
 ### 2. Open the dropdown without a human
 
 ```sh
-PID=$(pgrep -f "/Applications/AI Usage.app")
+PID=$(pgrep -f "/Applications/Tokens on Track.app")
 osascript -e "tell application \"System Events\" to tell (first process whose unix id is $PID) to get {position, size} of menu bar item 1 of menu bar 1"
 # -> 3179, 3, 147, 24   (x, y, w, h)
 cliclick c:3252,15                     # centre of the item

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# ai-usage-widget
+# Tokens on Track
 
-A macOS menu bar app showing how much of your **Claude Code** and **Codex**
+**Use every token. Never run dry.**
+
+Tokens on Track is a macOS menu bar app showing how much of your **Claude Code** and **Codex**
 quota you have burned, and whether you are burning it faster than the window
 refills. Refreshes every 15 minutes, and tells you when you are running hot.
 
 ```
-AI USAGE                          05:07
+TOKENS ON TRACK                   05:07
 Claude                             MAX
 5h          ▓▓▓─┃──────   18%     07:59
 week        ▓▓▓▓┃──────   22%  Sat 21:00
@@ -29,7 +31,7 @@ cd ai-usage-widget
 ./build.sh --install
 ```
 
-That compiles, wraps the binary in `AI Usage.app`, ad-hoc signs it, copies it to
+That compiles, wraps the binary in `Tokens on Track.app`, ad-hoc signs it, copies it to
 `/Applications` and launches it. Drop `--install` to build into `.build/` and
 leave `/Applications` alone.
 
@@ -158,7 +160,7 @@ copy with `AI_USAGE_ICONS=$PWD/Resources/Icons`, or just use `./build.sh`.
 
 macOS hides status items when the bar runs out of room, and menu bar managers
 (Bartender, Ice, Hidden Bar) park them off-screen by default. Check the app is
-alive with `pgrep -fl "AI Usage"`, then look in your manager's hidden section.
+alive with `pgrep -fl "Tokens on Track"`, then look in your manager's hidden section.
 
 **Desktop card missing**
 
@@ -169,7 +171,7 @@ that is no longer attached, it comes back to the top right on the next launch.
 **No notifications**
 
 The app asks for permission on first launch. If it was refused, re-enable it
-under System Settings → Notifications → AI Usage. Notifications need the app to
+under System Settings → Notifications → Tokens on Track. Notifications need the app to
 be signed, which `build.sh` handles — running the raw `swift build` binary skips
 them on purpose.
 
@@ -198,8 +200,8 @@ Hit **Refresh**; if that fails the per-provider error says why.
 ## Uninstall
 
 ```sh
-osascript -e 'quit app "AI Usage"'
-rm -rf "/Applications/AI Usage.app"
+osascript -e 'quit app "Tokens on Track"'
+rm -rf "/Applications/Tokens on Track.app"
 rm -rf ~/.local/share/ai-usage
 defaults delete io.github.ai-usage
 ```

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>AI Usage</string>
+	<string>Tokens on Track</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/Sources/AIUsage/DesktopCard.swift
+++ b/Sources/AIUsage/DesktopCard.swift
@@ -177,7 +177,7 @@ private struct CardWindowView: View {
                     Preferences.shared.showDesktopCard = false
                 }
                 Divider()
-                Button("Quit AI Usage") {
+                Button("Quit Tokens on Track") {
                     NSApplication.shared.terminate(nil)
                 }
             }

--- a/Sources/AIUsage/PanelView.swift
+++ b/Sources/AIUsage/PanelView.swift
@@ -102,7 +102,7 @@ private struct SettingsTab: View {
 
             // Quit stays put instead of hiding at the bottom of the scroll.
             footer
-                .padding(EdgeInsets(top: 0, leading: 18, bottom: 18, trailing: 18))
+                .padding(EdgeInsets(top: 12, leading: 18, bottom: 18, trailing: 18))
         }
     }
 
@@ -247,7 +247,7 @@ private struct SettingsTab: View {
 
     private var footer: some View {
         HStack(spacing: 12) {
-            Text("v\(Self.version) · io.github.ai-usage")
+            Text("Tokens on Track · v\(Self.version)")
                 .font(.system(size: 11))
                 .foregroundStyle(Glass.ink(0.4))
             Spacer(minLength: 8)

--- a/Sources/AIUsage/UsageCard.swift
+++ b/Sources/AIUsage/UsageCard.swift
@@ -71,7 +71,7 @@ struct DesktopUsageCard: View {
             )
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(verdict.source.map { "WORST — \($0.uppercased())" } ?? "AI USAGE")
+                Text(verdict.source.map { "WORST — \($0.uppercased())" } ?? "TOKENS ON TRACK")
                     .font(.system(size: 11, weight: .regular))
                     .kerning(1.4)
                     .foregroundStyle(Glass.ink(0.5))

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,15 @@
 #!/bin/sh
-# Build AI Usage.app from the SwiftPM target. Needs the Command Line Tools
+# Build Tokens on Track.app from the SwiftPM target. Needs the Command Line Tools
 # only — there is no Xcode project to open.
 #
-#   ./build.sh              build into .build/AI Usage.app
+#   ./build.sh              build into .build/Tokens on Track.app
 #   ./build.sh --install    also copy it to /Applications and launch it
 set -eu
 
 cd "$(dirname "$0")"
 
-APP_NAME="AI Usage"
+APP_NAME="Tokens on Track"
+LEGACY_APP_NAME="AI Usage"
 BUNDLE=".build/${APP_NAME}.app"
 INSTALL_DIR="/Applications"
 LEGACY_AGENT_DIR="${HOME}/Library/LaunchAgents"
@@ -35,7 +36,8 @@ codesign --force --sign - --timestamp=none "$BUNDLE"
 
 if [ "${1:-}" = "--install" ]; then
     echo "==> installing to ${INSTALL_DIR}"
-    osascript -e 'quit app "AI Usage"' 2>/dev/null || true
+    osascript -e "quit app \"${APP_NAME}\"" 2>/dev/null || true
+    osascript -e "quit app \"${LEGACY_APP_NAME}\"" 2>/dev/null || true
 
     # Retire both published launch-agent labels and the old Übersicht widget.
     # The Übersicht app and pipx package are left alone because they may still
@@ -48,6 +50,7 @@ if [ "${1:-}" = "--install" ]; then
     rm -f "$LEGACY_WIDGET"
 
     rm -rf "${INSTALL_DIR}/${APP_NAME}.app"
+    rm -rf "${INSTALL_DIR}/${LEGACY_APP_NAME}.app"
     cp -R "$BUNDLE" "${INSTALL_DIR}/"
     open "${INSTALL_DIR}/${APP_NAME}.app"
     echo "    running — look for the ring in the menu bar"


### PR DESCRIPTION
Renames the macOS app from AI Usage to Tokens on Track across bundle metadata, visible UI, documentation, and UI verification instructions.

Updates install and upgrade handling to quit and remove the legacy app while preserving internal identifiers, preferences, cache data, notifications, and login-item state.

Brands the Settings footer and adds spacing so it no longer crowds the final settings group.

Validated with ./test.sh, a signed release build, and an installed visual check.