### PR TITLE
Show percentages as pace, not only as budget spent

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ spark week  ▓───┃──────    1%  Mon 08:36
   Fill left of the tick, you are under budget; right of it, you are ahead.
 - **Colour** — pace, not absolute. Green at or under the even-burn line,
   orange up to 1.5× it, red beyond that or above 90% consumed.
+- **Percentage** — budget consumed by default, or pace when selected in Settings.
+  At 100% of pace, spending is exactly in step with the clock.
 - **Right column** — when the window resets, as a wall-clock time.
 
 ## Install
@@ -47,14 +49,14 @@ there is no `.xcodeproj`, `build.sh` assembles the bundle by hand.
 ## What you get
 
 **Menu bar.** The window in the most trouble, as its provider's logo, a ring
-filled to its consumption and tinted by its pace, and the percentage. Any of the
-three can be switched off, and you can widen it to as many as four windows,
-which are simply the busiest ones — two Claude windows if Claude owns the two
-busiest. Tick *Always keep every provider on screen* to hand each provider a
-slot first instead, so a quiet Codex stays visible beside a loud Claude at the
-cost of bumping a window that really is busier. The window's initial sits in the hole
-of the ring (`w` week, `h` 5-hour, `s` spark week), which is the one place a
-menu bar has room to spare. Click it for the dropdown.
+filled to its consumption and tinted by its pace, and the selected percentage
+reading. Any of the three can be switched off, and you can widen it to as many
+as four windows, which are simply the busiest ones — two Claude windows if
+Claude owns the two busiest. Tick *Always keep every provider on screen* to hand
+each provider a slot first instead, so a quiet Codex stays visible beside a loud
+Claude at the cost of bumping a window that really is busier. The window's
+initial sits in the hole of the ring (`w` week, `h` 5-hour, `s` spark week),
+which is the one place a menu bar has room to spare. Click it for the dropdown.
 
 **Dropdown.** Two tabs on a pane of glass. *Usage* leads with one line saying
 whether you are fine — "On pace everywhere", or how far ahead of an even burn
@@ -77,9 +79,10 @@ moment a window resets, the slate is wiped and the next crossing is announced
 again.
 
 The Settings tab groups them the way System Settings does: *Menu bar* (which
-parts to draw, how many windows), *Display* (desktop card on/off, its layer,
-open at login), *Alerts* (both thresholds, on sliders rather than steppers), and
-*Refresh* (5, 15, 30 or 60 minutes).
+parts to draw, how many windows), *Display* (whether percentages show budget
+spent or pace, desktop card on/off, its layer, open at login), *Alerts* (both
+thresholds, on sliders rather than steppers), and *Refresh* (5, 15, 30 or 60
+minutes).
 
 ### Why not a WidgetKit widget
 

--- a/Sources/AIUsage/MenuBarItem.swift
+++ b/Sources/AIUsage/MenuBarItem.swift
@@ -32,6 +32,7 @@ final class MenuBarItem {
     func start() {
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         item.button?.image = UsageStore.shared.statusImage
+        item.button?.toolTip = UsageStore.shared.statusTooltip
         item.button?.target = self
         item.button?.action = #selector(toggle)
         item.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
@@ -39,6 +40,10 @@ final class MenuBarItem {
 
         UsageStore.shared.$statusImage
             .sink { [weak self] image in self?.item?.button?.image = image }
+            .store(in: &watches)
+
+        UsageStore.shared.$statusTooltip
+            .sink { [weak self] text in self?.item?.button?.toolTip = text }
             .store(in: &watches)
     }
 

--- a/Sources/AIUsage/Pace.swift
+++ b/Sources/AIUsage/Pace.swift
@@ -149,7 +149,7 @@ enum Pace {
             return "\(lead)\(spent). Too early in the window to judge the pace."
         }
         let reading = """
-            \(lead)\(Int(index.rounded()))% of pace · \(spent), \
+            \(lead)\(Int(min(paceCeiling, index).rounded()))% of pace · \(spent), \
             \(Int(elapsed.rounded()))% of the window gone.
             """
         return explains ? "\(reading) \(paceExplainer)" : reading

--- a/Sources/AIUsage/Pace.swift
+++ b/Sources/AIUsage/Pace.swift
@@ -50,10 +50,24 @@ enum Pace {
         return min(100, max(0, elapsed / Double(length) * 100))
     }
 
+    /// Share of the window that has to be gone before a pace ratio is quoted at
+    /// all. Spending divided by a very small elapsed share swings wildly from
+    /// one poll to the next, so early on the answer is "not yet" rather than a
+    /// number that will look different in a minute.
+    ///
+    /// Two floors because the two uses can bear different amounts of noise. The
+    /// severity tier picks the colour of a row and the window the menu bar
+    /// speaks for, so it waits for the ratio to settle. A printed percentage is
+    /// read once, next to the reset time that explains why it is early, and
+    /// holding it back to match the colour left freshly reset windows with
+    /// nothing to say for hours.
+    static let severityFloor: Double = 5
+    static let displayFloor: Double = 1
+
     /// How far ahead of an even burn the window is. 1.0 is exactly on pace.
     /// Nil before the window has run long enough for the ratio to mean anything.
-    static func ratio(_ window: UsageWindow, now: Date = Date()) -> Double? {
-        guard let elapsed = elapsedPercent(window, now: now), elapsed >= 5 else { return nil }
+    static func ratio(_ window: UsageWindow, floor: Double = severityFloor, now: Date = Date()) -> Double? {
+        guard let elapsed = elapsedPercent(window, now: now), elapsed >= floor else { return nil }
         return window.percent / elapsed
     }
 
@@ -61,8 +75,84 @@ enum Pace {
     /// spending measured against the even-burn mark on the track rather than
     /// against the whole budget. 100 sits exactly on the mark, 150 is half
     /// again past it. Nil while the mark is still too early to mean anything.
-    static func paceIndex(_ window: UsageWindow, now: Date = Date()) -> Double? {
-        ratio(window, now: now).map { $0 * 100 }
+    static func paceIndex(
+        _ window: UsageWindow,
+        floor: Double = severityFloor,
+        now: Date = Date()
+    ) -> Double? {
+        ratio(window, floor: floor, now: now).map { $0 * 100 }
+    }
+
+    /// Which number the percentages quote. The gauges are unaffected either
+    /// way: a ring or a track always fills to the share of the budget spent,
+    /// because that is the only one of the two readings with an end to it.
+    enum PercentMode: String, CaseIterable {
+        /// How much of the budget is gone. 100% is the budget spent.
+        case budget
+        /// How that spending compares with an even burn. 100% sits exactly on
+        /// the even-burn mark, which is the white notch on the tracks.
+        case pace
+    }
+
+    /// A pace reading early in a window is a small number over a smaller one
+    /// and runs to four figures. Past this the exact value says nothing the cap
+    /// does not, and in the menu bar it would widen the item a digit at a time.
+    static let paceCeiling: Double = 999
+
+    /// What a column shows for a window that has no pace yet. Not the budget
+    /// number: the two readings share one column, so a budget percentage
+    /// printed under a "pace" heading is indistinguishable from a pace one and
+    /// silently means something else. The track beside it still fills to the
+    /// budget, and the reset time beside that says why the window is early.
+    static let noReading = "—"
+
+    /// The percentage a surface prints, and whether there was one to print.
+    struct Reading {
+        let text: String
+        /// False when the window is too young for a pace and pace was asked
+        /// for. The surfaces dim it, so an absent reading is not mistaken for
+        /// a very small one.
+        let hasValue: Bool
+    }
+
+    static func reading(_ window: UsageWindow, mode: PercentMode, now: Date = Date()) -> Reading {
+        guard mode == .pace else {
+            return Reading(text: "\(Int(window.percent.rounded()))%", hasValue: true)
+        }
+        guard let index = paceIndex(window, floor: displayFloor, now: now) else {
+            return Reading(text: noReading, hasValue: false)
+        }
+        return Reading(text: "\(Int(min(paceCeiling, index).rounded()))%", hasValue: true)
+    }
+
+    /// What a pace percentage is measured against. Said once per tooltip, not
+    /// once per window in it.
+    static let paceExplainer = "100% of pace is spending exactly in step with the clock."
+
+    /// The line behind the menu bar item. A bare "142%" cannot say which of the
+    /// two readings it is, so the tooltip states both and how far into the
+    /// window they were taken.
+    ///
+    /// `explains` appends `paceExplainer`; leave it off when several of these
+    /// are being stacked and the caller adds the sentence itself.
+    static func tooltip(
+        source: String?,
+        window: UsageWindow,
+        explains: Bool = true,
+        now: Date = Date()
+    ) -> String {
+        let spent = "\(Int(window.percent.rounded()))% of the budget spent"
+        let lead = source.map { "\($0) — " } ?? ""
+
+        guard let index = paceIndex(window, now: now), let elapsed = elapsedPercent(window, now: now)
+        else {
+            return "\(lead)\(spent). Too early in the window to judge the pace."
+        }
+        let reading = """
+            \(lead)\(Int(index.rounded()))% of pace · \(spent), \
+            \(Int(elapsed.rounded()))% of the window gone.
+            """
+        return explains ? "\(reading) \(paceExplainer)" : reading
     }
 
     /// Green while spending is at or under the even-burn pace, orange when
@@ -143,7 +233,15 @@ enum Pace {
         let hot: Bool
     }
 
-    static func verdict(_ report: Report?, now: Date = Date()) -> Verdict {
+    /// `mode` decides which reading the summary sentence quotes, so that it
+    /// agrees with the column of numbers underneath it. That agreement is what
+    /// labels the column: a heading over it was tried and read as clutter, and
+    /// this sentence was already on screen saying "70% of pace" in words.
+    static func verdict(
+        _ report: Report?,
+        mode: PercentMode = .budget,
+        now: Date = Date()
+    ) -> Verdict {
         guard let worst = report?.busiestWindows(limit: 1, now: now).first else {
             return Verdict(
                 headline: "No reading yet",
@@ -161,7 +259,7 @@ enum Pace {
         let window = worst.window
         let tier = severityTier(window, now: now)
         let exhausted = tier == 2 && window.percent >= 90
-        let reading = readingPhrase(window, now: now)
+        let reading = readingPhrase(window, mode: mode, now: now)
 
         let short: String
         switch tier {
@@ -185,12 +283,17 @@ enum Pace {
         )
     }
 
-    /// The number the summary quotes. Against the even-burn mark once there is
-    /// one, since "63% of the week" says nothing about whether that is early or
-    /// late; against the budget only while the window is too young for a mark.
-    private static func readingPhrase(_ window: UsageWindow, now: Date) -> String {
-        if let index = paceIndex(window, now: now) {
-            return "\(Int(index.rounded()))% of pace"
+    /// The number the summary quotes, named. Whichever reading the rows below
+    /// are showing, said in words — "70% of pace" or "36% of the week" — so the
+    /// bare percentages in the column inherit the noun from the sentence above
+    /// them.
+    ///
+    /// Pace mode still falls back to the budget here rather than to a dash. A
+    /// column of numbers has to be read against one heading and cannot carry
+    /// a substitution, but a sentence names whatever it is quoting.
+    private static func readingPhrase(_ window: UsageWindow, mode: PercentMode, now: Date) -> String {
+        if mode == .pace, let index = paceIndex(window, floor: displayFloor, now: now) {
+            return "\(Int(min(paceCeiling, index).rounded()))% of pace"
         }
         return "\(Int(window.percent.rounded()))% of \(phrase(window.label))"
     }

--- a/Sources/AIUsage/PanelView.swift
+++ b/Sources/AIUsage/PanelView.swift
@@ -172,6 +172,21 @@ private struct SettingsTab: View {
             groupTitle("Display")
 
             DividedRows {
+                SettingRow(
+                    title: "Percentages show",
+                    subtitle: "the gauges always fill to the budget spent"
+                ) {
+                    GlassSegmented(
+                        options: [.init(Pace.PercentMode.budget, "Budget"), .init(.pace, "Pace")],
+                        selection: $preferences.percentMode,
+                        fontSize: 11,
+                        verticalPadding: 4
+                    )
+                    .frame(width: 160)
+                    .onChange(of: preferences.percentMode) { _, _ in
+                        store.iconPreferenceChanged()
+                    }
+                }
                 SettingRow(title: "Card on desktop") {
                     GlassSwitch(isOn: $preferences.showDesktopCard)
                 }

--- a/Sources/AIUsage/Preferences.swift
+++ b/Sources/AIUsage/Preferences.swift
@@ -39,6 +39,14 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(menuBarFairShare, forKey: Keys.menuBarFairShare) }
     }
 
+    /// What every percentage in the app quotes — the budget spent, or that
+    /// spending measured against the clock. One knob for all three surfaces:
+    /// the same number meaning two different things in the menu bar and in the
+    /// card below it is worse than either reading on its own.
+    @Published var percentMode: Pace.PercentMode {
+        didSet { defaults.set(percentMode.rawValue, forKey: Keys.percentMode) }
+    }
+
     /// The free-standing card on the desktop.
     @Published var showDesktopCard: Bool {
         didSet { defaults.set(showDesktopCard, forKey: Keys.showDesktopCard) }
@@ -97,6 +105,7 @@ final class Preferences: ObservableObject {
         static let showWindow = "showWindowInMenuBar"
         static let menuBarSlots = "menuBarSlots"
         static let menuBarFairShare = "menuBarFairShare"
+        static let percentMode = "percentMode"
         static let showDesktopCard = "showDesktopCard"
         static let desktopCardFloats = "desktopCardFloats"
         static let desktopCardAnchor = "desktopCardAnchor"
@@ -115,6 +124,7 @@ final class Preferences: ObservableObject {
             Keys.showWindow: true,
             Keys.menuBarSlots: 1,
             Keys.menuBarFairShare: false,
+            Keys.percentMode: Pace.PercentMode.budget.rawValue,
             Keys.showDesktopCard: true,
             Keys.desktopCardFloats: false,
             Keys.usageThreshold: 90.0,
@@ -129,6 +139,8 @@ final class Preferences: ObservableObject {
         showWindowInMenuBar = defaults.bool(forKey: Keys.showWindow)
         menuBarSlots = max(1, defaults.integer(forKey: Keys.menuBarSlots))
         menuBarFairShare = defaults.bool(forKey: Keys.menuBarFairShare)
+        percentMode = defaults.string(forKey: Keys.percentMode)
+            .flatMap(Pace.PercentMode.init(rawValue:)) ?? .budget
         showDesktopCard = defaults.bool(forKey: Keys.showDesktopCard)
         desktopCardFloats = defaults.bool(forKey: Keys.desktopCardFloats)
         usageThreshold = defaults.double(forKey: Keys.usageThreshold)

--- a/Sources/AIUsage/StatusIcon.swift
+++ b/Sources/AIUsage/StatusIcon.swift
@@ -14,7 +14,13 @@ enum StatusIcon {
         var provider: String
         /// The window's own label, of which only the first letter is drawn.
         var window: String = ""
+        /// Fills the ring. Always the share of the budget spent, whichever
+        /// reading the text beside it quotes — a ring needs a number with an
+        /// end to it, and pace has none.
         var percent: Double?
+        /// The percentage as printed, already formatted by `Pace.reading` so
+        /// that the icon has no say in which of the two readings it is.
+        var text: String?
         var color: Color
     }
 
@@ -111,7 +117,7 @@ enum StatusIcon {
             widths.append(ring)
         }
         if parts.contains(.percent) {
-            widths.append(ceil(label(for: segment.percent).size(withAttributes: textAttributes).width))
+            widths.append(ceil(label(for: segment).size(withAttributes: textAttributes).width))
         }
         return widths.reduce(0, +) + partGap * CGFloat(max(0, widths.count - 1))
     }
@@ -141,7 +147,7 @@ enum StatusIcon {
 
         if parts.contains(.percent) {
             space()
-            let text = label(for: segment.percent)
+            let text = label(for: segment)
             let size = text.size(withAttributes: textAttributes)
             text.draw(at: NSPoint(x: x, y: (height - size.height) / 2), withAttributes: textAttributes)
         }
@@ -220,8 +226,7 @@ enum StatusIcon {
         arc.stroke()
     }
 
-    private static func label(for percent: Double?) -> NSString {
-        guard let percent else { return "--" }
-        return "\(Int(percent.rounded()))%" as NSString
+    private static func label(for segment: Segment) -> NSString {
+        (segment.text ?? "--") as NSString
     }
 }

--- a/Sources/AIUsage/UsageCard.swift
+++ b/Sources/AIUsage/UsageCard.swift
@@ -38,9 +38,10 @@ struct RowMetrics {
 /// provider with the word for how that provider on its own is doing.
 struct DesktopUsageCard: View {
     @EnvironmentObject private var store: UsageStore
+    @ObservedObject private var preferences = Preferences.shared
 
     var body: some View {
-        let verdict = Pace.verdict(store.report)
+        let verdict = Pace.verdict(store.report, mode: preferences.percentMode)
 
         VStack(alignment: .leading, spacing: 18) {
             header(verdict)
@@ -51,7 +52,12 @@ struct DesktopUsageCard: View {
 
             if let report = store.report {
                 ForEach(report.providers) { provider in
-                    ProviderBlock(provider: provider, metrics: .card, worstRow: verdict.rowKey)
+                    ProviderBlock(
+                        provider: provider,
+                        metrics: .card,
+                        mode: preferences.percentMode,
+                        worstRow: verdict.rowKey
+                    )
                 }
             } else {
                 Text(store.isRefreshing ? "fetching…" : "no data yet")
@@ -103,9 +109,10 @@ struct DesktopUsageCard: View {
 /// 1b — the Usage tab: one summary pill, then the same rows a size down.
 struct MenuUsageView: View {
     @EnvironmentObject private var store: UsageStore
+    @ObservedObject private var preferences = Preferences.shared
 
     var body: some View {
-        let verdict = Pace.verdict(store.report)
+        let verdict = Pace.verdict(store.report, mode: preferences.percentMode)
 
         VStack(alignment: .leading, spacing: 16) {
             summary(verdict)
@@ -118,6 +125,7 @@ struct MenuUsageView: View {
                         ProviderBlock(
                             provider: provider,
                             metrics: .menu,
+                            mode: preferences.percentMode,
                             showsNote: false,
                             worstRow: verdict.rowKey
                         )
@@ -208,6 +216,10 @@ struct OutageNotice: View {
 struct ProviderBlock: View {
     let provider: Provider
     let metrics: RowMetrics
+    /// Which reading the percentage column quotes. Passed down rather than read
+    /// from `Preferences` here, so one observer at the top of each surface
+    /// redraws the whole list.
+    var mode: Pace.PercentMode = .budget
     var showsNote: Bool = true
     /// The row the summary above is speaking for, marked here so the reader can
     /// trace the ring back to the window it came from.
@@ -249,6 +261,7 @@ struct ProviderBlock: View {
                     UsageRow(
                         window: window,
                         metrics: metrics,
+                        mode: mode,
                         isWorst: worstRow == Report.rowKey(provider: provider, window: window)
                     )
                 }
@@ -310,9 +323,12 @@ struct BrandMark: View {
 struct UsageRow: View {
     let window: UsageWindow
     let metrics: RowMetrics
+    var mode: Pace.PercentMode = .budget
     var isWorst: Bool = false
 
     var body: some View {
+        let reading = Pace.reading(window, mode: mode)
+
         HStack(spacing: metrics.gap) {
             // The dot sits in a gutter every row pays for, so marking a row
             // moves nothing.
@@ -335,10 +351,13 @@ struct UsageRow: View {
                 glows: metrics.glows
             )
 
-            Text("\(Int(window.percent.rounded()))%")
+            // Dimmed when there is nothing to report and when the window is too
+            // young to have a pace, so a dash reads as "not yet" rather than as
+            // a reading in its own right.
+            Text(reading.text)
                 .font(.system(size: metrics.percentSize, weight: .semibold))
                 .monospacedDigit()
-                .foregroundStyle(Glass.ink(window.percent < 0.5 ? 0.55 : 1))
+                .foregroundStyle(Glass.ink(window.percent < 0.5 || !reading.hasValue ? 0.55 : 1))
                 .frame(width: metrics.percent, alignment: .trailing)
 
             Text(Pace.resetLabel(window.resetsAt))

--- a/Sources/AIUsage/UsageStore.swift
+++ b/Sources/AIUsage/UsageStore.swift
@@ -14,6 +14,9 @@ final class UsageStore: ObservableObject {
     @Published private(set) var report: Report?
     @Published private(set) var isRefreshing = false
     @Published private(set) var statusImage: NSImage = StatusIcon.image(segments: [])
+    /// Spells out both readings for whatever the item is drawn as, since the
+    /// icon has room for one number and no room at all to label it.
+    @Published private(set) var statusTooltip: String = "Tokens on Track — no reading yet"
 
     static var stateDirectory: URL {
         if let override = ProcessInfo.processInfo.environment["AI_USAGE_DIR"], !override.isEmpty {
@@ -95,14 +98,29 @@ final class UsageStore: ObservableObject {
 
     private func redrawIcon() {
         let preferences = Preferences.shared
-        let segments = menuBarWindows(limit: preferences.menuBarSlots).map {
+        let shown = menuBarWindows(limit: preferences.menuBarSlots)
+        let segments = shown.map {
             StatusIcon.Segment(
                 provider: $0.provider.name,
                 window: $0.window.label,
                 percent: $0.window.percent,
+                text: Pace.reading($0.window, mode: preferences.percentMode).text,
                 color: Pace.color($0.window)
             )
         }
+
+        // One line per segment drawn, in the order they appear in the bar, and
+        // the sentence explaining pace once at the end rather than on each.
+        let lines = shown.map {
+            Pace.tooltip(
+                source: "\($0.provider.name) \($0.window.label)",
+                window: $0.window,
+                explains: false
+            )
+        }
+        statusTooltip = lines.isEmpty
+            ? "Tokens on Track — no reading yet"
+            : (lines + [Pace.paceExplainer]).joined(separator: "\n")
 
         var parts: StatusIcon.Parts = []
         if preferences.showLogoInMenuBar { parts.insert(.mark) }

--- a/Tests/RegressionTests.swift
+++ b/Tests/RegressionTests.swift
@@ -324,8 +324,16 @@ enum RegressionTests {
     private static func testPaceReadingIsCapped() {
         // 100% of the budget spent in 5% of the window is 2000% of pace, which
         // would widen the menu bar item without telling the reader anything.
-        let reading = Pace.reading(window(percent: 100, elapsedPercent: 5), mode: .pace, now: now)
+        let runaway = window(percent: 100, elapsedPercent: 5)
+        let reading = Pace.reading(runaway, mode: .pace, now: now)
         check(reading.text == "999%", "a runaway pace must be capped, got \(reading.text)")
+
+        let tooltip = Pace.tooltip(source: nil, window: runaway, now: now)
+        check(
+            tooltip.contains("999% of pace"),
+            "the tooltip must agree with the capped pace reading, got \(tooltip)"
+        )
+        check(!tooltip.contains("2000% of pace"), "the tooltip must not expose the uncapped reading")
     }
 
     private static func testTooltipStatesBothReadings() {

--- a/Tests/RegressionTests.swift
+++ b/Tests/RegressionTests.swift
@@ -22,6 +22,12 @@ enum RegressionTests {
         testFailedPollKeepsTheLastReading()
         testCarriedReadingIsDroppedOnceItIsOld()
         testCarriedWindowIsDroppedOnceItHasReset()
+        testBudgetModeQuotesTheBudget()
+        testPaceModeQuotesThePaceIndex()
+        testPaceModeSaysNothingWhileTheWindowIsYoung()
+        testPaceIsPrintedSoonerThanItIsColoured()
+        testPaceReadingIsCapped()
+        testTooltipStatesBothReadings()
         print("All regression tests passed")
     }
 
@@ -269,6 +275,73 @@ enum RegressionTests {
         let onlySpent = Report(providers: [provider(name: "Claude", windows: [spent])], date: now)
         let emptied = Report(providers: [failed], date: later).carryingOver(from: onlySpent, now: later)
         check(!emptied.providers[0].ok, "a provider whose every carried window has reset is not ok")
+    }
+
+    private static func testBudgetModeQuotesTheBudget() {
+        // Half the budget a quarter of the way in — 50 against the budget, 200
+        // against the clock. Budget mode must not be tempted by the latter.
+        let reading = Pace.reading(window(percent: 50, elapsedPercent: 25), mode: .budget, now: now)
+        check(reading.text == "50%", "budget mode must quote the budget, got \(reading.text)")
+        check(reading.hasValue, "a budget reading always has a value")
+    }
+
+    private static func testPaceModeQuotesThePaceIndex() {
+        let reading = Pace.reading(window(percent: 50, elapsedPercent: 25), mode: .pace, now: now)
+        check(reading.text == "200%", "pace mode must quote the pace index, got \(reading.text)")
+        check(reading.hasValue, "a pace index that exists is a value")
+    }
+
+    private static func testPaceModeSaysNothingWhileTheWindowIsYoung() {
+        // The budget number must NOT stand in here. Both readings share one
+        // column, so a budget percentage printed under a pace heading is
+        // indistinguishable from a pace one and quietly means something else —
+        // which is exactly how "2% of pace" and "2% of budget" came to look
+        // like the same reading for a window that had just reset.
+        let reading = Pace.reading(window(percent: 3, elapsedPercent: 0.5), mode: .pace, now: now)
+        check(
+            reading.text == Pace.noReading,
+            "a window too young for a pace must print a dash, got \(reading.text)"
+        )
+        check(!reading.hasValue, "an absent pace must not claim to have a value")
+        check(reading.text != "3%", "the budget number must never stand in for a pace")
+    }
+
+    private static func testPaceIsPrintedSoonerThanItIsColoured() {
+        // Between the two floors: settled enough to print next to the reset
+        // time that explains it, not settled enough to recolour the row or to
+        // decide which window the menu bar speaks for.
+        let young = window(percent: 2, elapsedPercent: 2)
+        check(
+            Pace.reading(young, mode: .pace, now: now).text == "100%",
+            "a window past the display floor must print its pace"
+        )
+        check(
+            Pace.ratio(young, now: now) == nil,
+            "the same window must still be too young to be given a severity tier"
+        )
+    }
+
+    private static func testPaceReadingIsCapped() {
+        // 100% of the budget spent in 5% of the window is 2000% of pace, which
+        // would widen the menu bar item without telling the reader anything.
+        let reading = Pace.reading(window(percent: 100, elapsedPercent: 5), mode: .pace, now: now)
+        check(reading.text == "999%", "a runaway pace must be capped, got \(reading.text)")
+    }
+
+    private static func testTooltipStatesBothReadings() {
+        let tooltip = Pace.tooltip(
+            source: "Claude 5h",
+            window: window(percent: 50, elapsedPercent: 25),
+            now: now
+        )
+        for expected in ["Claude 5h", "200% of pace", "50% of the budget", "25% of the window"] {
+            check(tooltip.contains(expected), "tooltip must state \(expected), got: \(tooltip)")
+        }
+
+        // With no pace to state it has to say why rather than quote a number.
+        let young = Pace.tooltip(source: nil, window: window(percent: 3, elapsedPercent: 2), now: now)
+        check(!young.contains("of pace"), "a window with no pace must not be given one")
+        check(young.contains("3% of the budget"), "the budget is stated either way")
     }
 
     // ----------------------------------------------------------------- //


### PR DESCRIPTION
Adds a Settings → Display control, **Percentages show: Budget / Pace**, that switches every percentage in the app between the share of the budget spent and that spending measured against the clock, where 100% is exactly in step with the white even-burn mark already drawn on each track.

The gauges are deliberately untouched: a ring or a track always fills to the budget spent, since that is the only one of the two readings with an end to it — so the bar answers "how much is left" while the number beside it answers "am I ahead of the clock".

Because both readings share one column, the summary sentence at the top of the card and the dropdown now follows the setting ("On pace — 70% of pace" over a column of pace, "On pace — 36% of the week" over a column of budget), quoting the same row it already marks with a dot; a window too young to have a pace prints a dash rather than silently substituting the budget number, and the menu bar item — which has room for neither — gains a tooltip stating both readings.

A pace is now printed from 1% of a window elapsed instead of 5%, so a freshly reset window is no longer mute for hours, while the 5% floor stays in place for the severity tier that picks row colours and ranks windows and must not flicker; runaway early paces are capped at 999% so the menu bar item cannot grow a digit at a time.

Verified against the installed app in both modes, with six new regression tests covering the two floors, the cap, and the rule that a budget number never stands in for a pace.