### PR TITLE
Add working-hours targets for quota pacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,14 @@ spark week  ▓───┃──────    1%  Mon 08:36
 - **Bar** — quota consumed in that window.
 - **`┃` tick** — where the bar *should* be if you spent the window evenly.
   Fill left of the tick, you are under budget; right of it, you are ahead.
-- **Colour** — pace, not absolute. Green at or under the even-burn line,
-  orange up to 1.5× it, red beyond that or above 90% consumed.
-- **Percentage** — budget consumed by default, or pace when selected in Settings.
-  At 100% of pace, spending is exactly in step with the clock.
+- **Colour** — position against the target, not absolute usage. Green at or
+  under the target, orange up to 1.5× it, red beyond that or above 90% consumed.
+- **Percentage** — quota used by default, or usage compared with the even-spend
+  target when *Vs target* is selected in Settings. At 100% of target, spending
+  is exactly where it should be now.
+- **Working hours** — optionally spread the full quota over selected weekdays
+  and hours while you are inside that schedule. Outside it, the target returns
+  to the ordinary wall clock.
 - **Right column** — when the window resets, as a wall-clock time.
 
 ## Install
@@ -49,9 +53,9 @@ there is no `.xcodeproj`, `build.sh` assembles the bundle by hand.
 ## What you get
 
 **Menu bar.** The window in the most trouble, as its provider's logo, a ring
-filled to its consumption and tinted by its pace, and the selected percentage
-reading. Any of the three can be switched off, and you can widen it to as many
-as four windows, which are simply the busiest ones — two Claude windows if
+filled to its consumption and tinted by its position against the target, and
+the selected percentage reading. Any of the three can be switched off, and you
+can widen it to as many as four windows, which are simply the busiest ones — two Claude windows if
 Claude owns the two busiest. Tick *Always keep every provider on screen* to hand
 each provider a slot first instead, so a quiet Codex stays visible beside a loud
 Claude at the cost of bumping a window that really is busier. The window's
@@ -59,7 +63,7 @@ initial sits in the hole of the ring (`w` week, `h` 5-hour, `s` spark week),
 which is the one place a menu bar has room to spare. Click it for the dropdown.
 
 **Dropdown.** Two tabs on a pane of glass. *Usage* leads with one line saying
-whether you are fine — "On pace everywhere", or how far ahead of an even burn
+whether you are fine — "On target everywhere", or how far above the target
 the worst window is — then a row per window, with a **Refresh** button beside
 the tabs. *Settings* holds everything else, so opening it can no longer push the
 reading off the bottom of the screen.
@@ -74,15 +78,30 @@ by default — set *Card layer* to *Floating* to keep it in front instead.
 Right-click it for refresh, hide and quit.
 
 **Notifications.** One alert when a window passes your threshold, one when it is
-burning faster than your pace multiple. Each fires at most once per window; the
+above your target multiple. Each fires at most once per window; the
 moment a window resets, the slate is wiped and the next crossing is announced
 again.
 
 The Settings tab groups them the way System Settings does: *Menu bar* (which
-parts to draw, how many windows), *Display* (whether percentages show budget
-spent or pace, desktop card on/off, its layer, open at login), *Alerts* (both
-thresholds, on sliders rather than steppers), and *Refresh* (5, 15, 30 or 60
-minutes).
+parts to draw, how many windows), *Display* (whether percentages show *Used* or
+*Vs target*, desktop card on/off, its layer, open at login), *Working hours*
+(selected days and one shared time range), *Alerts* (both thresholds, on
+sliders rather than steppers), and *Refresh* (5, 15, 30 or 60 minutes).
+
+### Working-hours target
+
+The working-hours target is optional and off by default. While the current
+local time is inside the selected schedule, each provider window's full 100%
+quota is spread evenly over every selected working hour contained in that
+window. That also redistributes the shares that a wall-clock target would have
+assigned to evenings and weekends.
+
+When the current time leaves the schedule, every window deliberately switches
+back to an ordinary wall-clock target. The white target notch, target
+percentage, colour, worst-window ranking and target alerts all use the active
+calculation, so they may jump at the boundary. Target alerts are never
+suppressed outside working hours. Windows with no scheduled overlap also use a
+wall-clock target.
 
 ### Why not a WidgetKit widget
 
@@ -103,12 +122,13 @@ bar ring, the dropdown and the desktop card can never disagree.
 | --- | --- |
 | `Fetcher.swift` | reads both credential stores, calls both usage APIs |
 | `Report.swift` | the JSON written to the cache |
-| `Pace.swift` | elapsed share, pace ratio, colours, reset labels |
+| `WorkSchedule.swift` | local working intervals, DST and schedule boundaries |
+| `Pace.swift` | target share, active time basis, pace rate, colours, reset labels |
 | `UsageCard.swift` | the reading, shared by the dropdown and the desktop card |
 | `Glass.swift` | the glass surfaces, tracks, ring and controls both are built from |
 | `StatusIcon.swift` | the menu bar item — logo, ring, percentage |
 | `BrandGlyph.swift` | reads `Resources/Icons/*.svg` into drawable outlines |
-| `Notifier.swift` | threshold and pace alerts, one per window instance |
+| `Notifier.swift` | threshold and target alerts, one per window instance |
 | `UsageStore.swift` | the single reading, its timer, and the cache |
 
 ### Where the numbers come from

--- a/Sources/AIUsage/DesktopCard.swift
+++ b/Sources/AIUsage/DesktopCard.swift
@@ -156,11 +156,13 @@ final class DesktopCard {
 /// card is glanced at, not read, so the state has to survive peripheral vision.
 private struct CardWindowView: View {
     @EnvironmentObject private var store: UsageStore
+    @ObservedObject private var preferences = Preferences.shared
 
     var body: some View {
-        let hot = Pace.verdict(store.report).hot
+        let timing = Pace.Timing(schedule: preferences.workSchedule)
+        let hot = Pace.verdict(store.report, timing: timing).hot
 
-        DesktopUsageCard()
+        DesktopUsageCard(timing: timing)
             .padding(EdgeInsets(top: 20, leading: 22, bottom: 18, trailing: 22))
             // The drop shadow is the panel's own: a SwiftUI one would be
             // clipped by the window it is drawn inside.

--- a/Sources/AIUsage/Glass.swift
+++ b/Sources/AIUsage/Glass.swift
@@ -166,10 +166,10 @@ extension View {
 // --------------------------------------------------------------------- //
 
 /// The consumption bar: a groove cut into the glass, a fill that glows, and
-/// the even-burn mark as a notch straight through both.
+/// the current target as a notch straight through both.
 struct UsageTrack: View {
     let percent: Double
-    let elapsed: Double?
+    let target: Double?
     let palette: Pace.Palette
     var height: CGFloat = 10
     var glows: Bool = true
@@ -190,12 +190,12 @@ struct UsageTrack: View {
                 fill(in: width, radius: radius)
 
                 // Where usage *should* be if spent evenly across the window.
-                if let elapsed, elapsed > 0 {
+                if let target, target > 0 {
                     RoundedRectangle(cornerRadius: 1, style: .continuous)
                         .fill(Color.white.opacity(0.85))
                         .frame(width: 2, height: height + 6)
                         .shadow(color: .black.opacity(0.4), radius: 3)
-                        .offset(x: min(width - 2, width * elapsed / 100 - 1))
+                        .offset(x: min(width - 2, width * target / 100 - 1))
                 }
             }
         }
@@ -217,12 +217,12 @@ struct UsageTrack: View {
 }
 
 /// The donut in the summary line: one glance at the worst window. Carries the
-/// same even-burn mark as the tracks, so "how much is gone" and "how far into
-/// the window we are" are read off one shape.
-struct PaceRing: View {
+/// same target mark as the tracks, so usage and where it should be now are read
+/// off one shape.
+struct UsageRing: View {
     let percent: Double
     let color: Color
-    var elapsed: Double? = nil
+    var target: Double? = nil
     var size: CGFloat = 40
 
     var body: some View {
@@ -235,13 +235,13 @@ struct PaceRing: View {
                 .stroke(color, style: StrokeStyle(lineWidth: line, lineCap: .round))
                 .rotationEffect(.degrees(-90))
 
-            if let elapsed, elapsed > 0 {
+            if let target, target > 0 {
                 Capsule()
                     .fill(Color.white.opacity(0.85))
                     .frame(width: 2, height: line + 5)
                     .shadow(color: .black.opacity(0.4), radius: 2)
                     .offset(y: -(size - line) / 2)
-                    .rotationEffect(.degrees(min(100, elapsed) / 100 * 360))
+                    .rotationEffect(.degrees(min(100, target) / 100 * 360))
             }
         }
         .frame(width: size, height: size)

--- a/Sources/AIUsage/Notifier.swift
+++ b/Sources/AIUsage/Notifier.swift
@@ -27,9 +27,14 @@ enum Notifier {
     }
 
     /// Compare a fresh report against what has already been announced.
-    static func evaluate(_ report: Report, preferences: Preferences = .shared) {
+    static func evaluate(
+        _ report: Report,
+        preferences: Preferences = .shared,
+        evaluateUsage: Bool = true
+    ) {
         guard isBundled else { return }
         var marks = loadMarks()
+        let timing = Pace.Timing(schedule: preferences.workSchedule)
 
         // Carried-over numbers were already judged when they were fresh; a
         // stale provider must not be able to raise an alert twice.
@@ -43,7 +48,8 @@ enum Notifier {
                     mark = Mark(resetsAt: window.resetsAt)
                 }
 
-                if preferences.usageAlertsEnabled,
+                if evaluateUsage,
+                   preferences.usageAlertsEnabled,
                    !mark.usageSent,
                    window.percent >= preferences.usageThreshold {
                     mark.usageSent = true
@@ -59,12 +65,13 @@ enum Notifier {
                 if preferences.paceAlertsEnabled,
                    !mark.paceSent,
                    window.percent >= 10,
-                   let ratio = Pace.ratio(window), ratio > preferences.paceThreshold {
+                   let ratio = Pace.ratio(window, timing: timing),
+                   ratio > preferences.paceThreshold {
                     mark.paceSent = true
                     post(
-                        title: "\(provider.name) \(window.label) burning fast",
+                        title: "\(provider.name) \(window.label) above target",
                         body: String(
-                            format: "%.0f%% used at %.1f× the even pace. Resets %@.",
+                            format: "%.0f%% used at %.1f× target. Resets %@.",
                             window.percent, ratio, Pace.resetLabel(window.resetsAt)
                         ),
                         id: "\(key)/pace/\(window.resetsAt ?? 0)"

--- a/Sources/AIUsage/Pace.swift
+++ b/Sources/AIUsage/Pace.swift
@@ -39,15 +39,83 @@ enum Pace {
         }
     }
 
-    /// Share of the window already elapsed, 0-100. Nil when the window length
-    /// or reset time is unknown, in which case absolute thresholds are used.
-    static func elapsedPercent(_ window: UsageWindow, now: Date = Date()) -> Double? {
+    enum ClockBasis {
+        case wallClock
+        case workingHours
+
+        var label: String {
+            switch self {
+            case .wallClock: return "wall clock"
+            case .workingHours: return "working hours"
+            }
+        }
+    }
+
+    /// One instant and schedule shared by every pace decision made while a
+    /// surface is rendered. This prevents a boundary crossing halfway through
+    /// a render from giving the notch and its colour different answers.
+    struct Timing {
+        let now: Date
+        let schedule: WorkSchedule
+        let calendar: Calendar
+
+        init(
+            now: Date = Date(),
+            schedule: WorkSchedule = .disabled,
+            calendar: Calendar = .autoupdatingCurrent
+        ) {
+            self.now = now
+            self.schedule = schedule
+            self.calendar = calendar
+        }
+    }
+
+    /// Where usage should be now, expressed as a share of the quota. The basis
+    /// records which clock supplied that target.
+    struct Target {
+        let percent: Double
+        let basis: ClockBasis
+    }
+
+    /// The even-spend target, 0-100. While the user is inside working hours,
+    /// the full quota is spread over every scheduled second in the window.
+    /// Outside them — or when the window contains none — wall time supplies the
+    /// target instead.
+    static func target(_ window: UsageWindow, timing: Timing = Timing()) -> Target? {
         guard let resetsAt = window.resetsAt, let length = window.windowSeconds, length > 0 else {
             return nil
         }
-        let remaining = Double(resetsAt) - now.timeIntervalSince1970
+        let reset = Date(timeIntervalSince1970: Double(resetsAt))
+        let start = reset.addingTimeInterval(-Double(length))
+
+        if timing.schedule.isActive(at: timing.now, calendar: timing.calendar) {
+            let whole = DateInterval(start: start, end: reset)
+            let total = timing.schedule.scheduledSeconds(in: whole, calendar: timing.calendar)
+            if total > 0 {
+                let end = min(reset, max(start, timing.now))
+                let passed = end > start
+                    ? timing.schedule.scheduledSeconds(
+                        in: DateInterval(start: start, end: end),
+                        calendar: timing.calendar
+                    )
+                    : 0
+                return Target(
+                    percent: min(100, max(0, passed / total * 100)),
+                    basis: .workingHours
+                )
+            }
+        }
+
+        let remaining = Double(resetsAt) - timing.now.timeIntervalSince1970
         let elapsed = Double(length) - remaining
-        return min(100, max(0, elapsed / Double(length) * 100))
+        return Target(
+            percent: min(100, max(0, elapsed / Double(length) * 100)),
+            basis: .wallClock
+        )
+    }
+
+    static func targetPercent(_ window: UsageWindow, timing: Timing = Timing()) -> Double? {
+        target(window, timing: timing)?.percent
     }
 
     /// Share of the window that has to be gone before a pace ratio is quoted at
@@ -66,9 +134,13 @@ enum Pace {
 
     /// How far ahead of an even burn the window is. 1.0 is exactly on pace.
     /// Nil before the window has run long enough for the ratio to mean anything.
-    static func ratio(_ window: UsageWindow, floor: Double = severityFloor, now: Date = Date()) -> Double? {
-        guard let elapsed = elapsedPercent(window, now: now), elapsed >= floor else { return nil }
-        return window.percent / elapsed
+    static func ratio(
+        _ window: UsageWindow,
+        floor: Double = severityFloor,
+        timing: Timing = Timing()
+    ) -> Double? {
+        guard let target = targetPercent(window, timing: timing), target >= floor else { return nil }
+        return window.percent / target
     }
 
     /// The same reading as a percentage, which is how the summary states it:
@@ -78,9 +150,9 @@ enum Pace {
     static func paceIndex(
         _ window: UsageWindow,
         floor: Double = severityFloor,
-        now: Date = Date()
+        timing: Timing = Timing()
     ) -> Double? {
-        ratio(window, floor: floor, now: now).map { $0 * 100 }
+        ratio(window, floor: floor, timing: timing).map { $0 * 100 }
     }
 
     /// Which number the percentages quote. The gauges are unaffected either
@@ -90,8 +162,9 @@ enum Pace {
         /// How much of the budget is gone. 100% is the budget spent.
         case budget
         /// How that spending compares with an even burn. 100% sits exactly on
-        /// the even-burn mark, which is the white notch on the tracks.
-        case pace
+        /// the target mark, which is the white notch on the tracks. The legacy
+        /// raw value preserves existing saved preferences.
+        case target = "pace"
     }
 
     /// A pace reading early in a window is a small number over a smaller one
@@ -99,74 +172,81 @@ enum Pace {
     /// does not, and in the menu bar it would widen the item a digit at a time.
     static let paceCeiling: Double = 999
 
-    /// What a column shows for a window that has no pace yet. Not the budget
+    /// What a column shows for a window that has no stable target comparison
+    /// yet. Not the budget
     /// number: the two readings share one column, so a budget percentage
-    /// printed under a "pace" heading is indistinguishable from a pace one and
-    /// silently means something else. The track beside it still fills to the
-    /// budget, and the reset time beside that says why the window is early.
+    /// printed under a target heading is indistinguishable from a target
+    /// comparison and silently means something else. The track beside it still
+    /// fills to the budget, and the reset time beside that says why the window
+    /// is early.
     static let noReading = "—"
 
     /// The percentage a surface prints, and whether there was one to print.
     struct Reading {
         let text: String
-        /// False when the window is too young for a pace and pace was asked
-        /// for. The surfaces dim it, so an absent reading is not mistaken for
-        /// a very small one.
+        /// False when the window is too young for a stable target comparison
+        /// and target mode was asked for. The surfaces dim it, so an absent
+        /// reading is not mistaken for a very small one.
         let hasValue: Bool
     }
 
-    static func reading(_ window: UsageWindow, mode: PercentMode, now: Date = Date()) -> Reading {
-        guard mode == .pace else {
+    static func reading(
+        _ window: UsageWindow,
+        mode: PercentMode,
+        timing: Timing = Timing()
+    ) -> Reading {
+        guard mode == .target else {
             return Reading(text: "\(Int(window.percent.rounded()))%", hasValue: true)
         }
-        guard let index = paceIndex(window, floor: displayFloor, now: now) else {
+        guard let index = paceIndex(window, floor: displayFloor, timing: timing) else {
             return Reading(text: noReading, hasValue: false)
         }
         return Reading(text: "\(Int(min(paceCeiling, index).rounded()))%", hasValue: true)
     }
 
-    /// What a pace percentage is measured against. Said once per tooltip, not
+    /// What a target percentage is measured against. Said once per tooltip, not
     /// once per window in it.
-    static let paceExplainer = "100% of pace is spending exactly in step with the clock."
+    static let targetExplainer = "100% of target means usage is exactly where it should be now."
 
     /// The line behind the menu bar item. A bare "142%" cannot say which of the
     /// two readings it is, so the tooltip states both and how far into the
     /// window they were taken.
     ///
-    /// `explains` appends `paceExplainer`; leave it off when several of these
+    /// `explains` appends `targetExplainer`; leave it off when several of these
     /// are being stacked and the caller adds the sentence itself.
     static func tooltip(
         source: String?,
         window: UsageWindow,
         explains: Bool = true,
-        now: Date = Date()
+        timing: Timing = Timing()
     ) -> String {
         let spent = "\(Int(window.percent.rounded()))% of the budget spent"
         let lead = source.map { "\($0) — " } ?? ""
+        let target = target(window, timing: timing)
 
-        guard let index = paceIndex(window, now: now), let elapsed = elapsedPercent(window, now: now)
-        else {
-            return "\(lead)\(spent). Too early in the window to judge the pace."
+        guard let index = paceIndex(window, timing: timing), let target else {
+            let basis = target.map { basisSentence($0, timing: timing) } ?? ""
+            return "\(lead)\(spent). Too early in the window to compare with the target.\(basis)"
         }
         let reading = """
-            \(lead)\(Int(min(paceCeiling, index).rounded()))% of pace · \(spent), \
-            \(Int(elapsed.rounded()))% of the window gone.
+            \(lead)\(Int(min(paceCeiling, index).rounded()))% of target · \(spent), \
+            \(basisReading(target, timing: timing)).
             """
-        return explains ? "\(reading) \(paceExplainer)" : reading
+        return explains ? "\(reading) \(targetExplainer)" : reading
     }
 
     /// Green while spending is at or under the even-burn pace, orange when
     /// running ahead of it, red when far ahead or nearly exhausted.
-    static func color(_ window: UsageWindow, now: Date = Date()) -> Color {
-        switch severityTier(window, now: now) {
+    static func color(_ window: UsageWindow, timing: Timing = Timing()) -> Color {
+        switch severityTier(window, timing: timing) {
         case 2: return bad
         case 1: return warn
         default: return good
         }
     }
 
-    static func palette(_ window: UsageWindow, now: Date = Date()) -> Palette {
-        switch severityTier(window, now: now) {
+    static func palette(_ window: UsageWindow, timing: Timing = Timing()) -> Palette {
+        switch severityTier(window, timing: timing) {
         case 2:
             return Palette(
                 base: bad,
@@ -188,9 +268,9 @@ enum Pace {
         }
     }
 
-    private static func severityTier(_ window: UsageWindow, now: Date) -> Int {
+    private static func severityTier(_ window: UsageWindow, timing: Timing) -> Int {
         if window.percent >= 90 { return 2 }
-        guard let ratio = ratio(window, now: now) else {
+        guard let ratio = ratio(window, timing: timing) else {
             // Too early in the window for a pace ratio to mean anything.
             if window.percent >= 60 { return 2 }
             if window.percent >= 30 { return 1 }
@@ -204,11 +284,11 @@ enum Pace {
     /// Ranking used to pick which window the menu bar should speak for: the one
     /// in the most trouble. Colour tier wins first, then usage and pace break
     /// ties without collapsing high percentages into the same capped score.
-    static func severity(_ window: UsageWindow, now: Date = Date()) -> Severity {
+    static func severity(_ window: UsageWindow, timing: Timing = Timing()) -> Severity {
         Severity(
-            tier: severityTier(window, now: now),
+            tier: severityTier(window, timing: timing),
             percent: window.percent,
-            pace: ratio(window, now: now) ?? 0
+            pace: ratio(window, timing: timing) ?? 0
         )
     }
 
@@ -221,8 +301,8 @@ enum Pace {
         let line: String
         let detail: String
         let percent: Double
-        /// Share of the window elapsed, for the ring's even-burn mark.
-        let elapsed: Double?
+        /// Even-spend target, for the ring's white target mark.
+        let target: Double?
         /// "Anthropic 5h" — the row the whole summary is speaking about, named
         /// so that the ring is not an anonymous number.
         let source: String?
@@ -236,19 +316,19 @@ enum Pace {
     /// `mode` decides which reading the summary sentence quotes, so that it
     /// agrees with the column of numbers underneath it. That agreement is what
     /// labels the column: a heading over it was tried and read as clutter, and
-    /// this sentence was already on screen saying "70% of pace" in words.
+    /// this sentence is already on screen saying "70% of target" in words.
     static func verdict(
         _ report: Report?,
         mode: PercentMode = .budget,
-        now: Date = Date()
+        timing: Timing = Timing()
     ) -> Verdict {
-        guard let worst = report?.busiestWindows(limit: 1, now: now).first else {
+        guard let worst = report?.busiestWindows(limit: 1, timing: timing).first else {
             return Verdict(
                 headline: "No reading yet",
                 line: "No reading yet",
                 detail: "nothing fetched",
                 percent: 0,
-                elapsed: nil,
+                target: nil,
                 source: nil,
                 rowKey: nil,
                 color: good,
@@ -257,43 +337,51 @@ enum Pace {
         }
 
         let window = worst.window
-        let tier = severityTier(window, now: now)
+        let tier = severityTier(window, timing: timing)
         let exhausted = tier == 2 && window.percent >= 90
-        let reading = readingPhrase(window, mode: mode, now: now)
+        let reading = readingPhrase(window, mode: mode, timing: timing)
+        let basis = target(window, timing: timing)
+        let basisSuffix = timing.schedule.enabled
+            ? basis.map { " · \($0.basis.label)" } ?? " · wall clock"
+            : ""
 
         let short: String
         switch tier {
-        case 2: short = "Well ahead of pace"
-        case 1: short = "Ahead of pace"
-        default: short = "On pace"
+        case 2: short = "Well above target"
+        case 1: short = "Above target"
+        default: short = "On target"
         }
 
         return Verdict(
-            headline: exhausted ? "\(window.label) window nearly out" : (tier == 0 ? "On pace everywhere" : short),
+            headline: exhausted ? "\(window.label) window nearly out" : (tier == 0 ? "On target everywhere" : short),
             line: exhausted
-                ? "\(window.label) window nearly out — \(reading)"
-                : "\(short) — \(reading)",
-            detail: "worst: \(worst.provider.name) \(window.label), \(reading)",
+                ? "\(window.label) window nearly out — \(reading)\(basisSuffix)"
+                : "\(short) — \(reading)\(basisSuffix)",
+            detail: "worst: \(worst.provider.name) \(window.label), \(reading)\(basisSuffix)",
             percent: window.percent,
-            elapsed: elapsedPercent(window, now: now),
+            target: basis?.percent,
             source: "\(worst.provider.name) \(window.label)",
             rowKey: Report.rowKey(provider: worst.provider, window: window),
-            color: color(window, now: now),
+            color: color(window, timing: timing),
             hot: tier == 2
         )
     }
 
     /// The number the summary quotes, named. Whichever reading the rows below
-    /// are showing, said in words — "70% of pace" or "36% of the week" — so the
+    /// are showing, said in words — "70% of target" or "36% of the week" — so the
     /// bare percentages in the column inherit the noun from the sentence above
     /// them.
     ///
-    /// Pace mode still falls back to the budget here rather than to a dash. A
+    /// Target mode still falls back to the budget here rather than to a dash. A
     /// column of numbers has to be read against one heading and cannot carry
     /// a substitution, but a sentence names whatever it is quoting.
-    private static func readingPhrase(_ window: UsageWindow, mode: PercentMode, now: Date) -> String {
-        if mode == .pace, let index = paceIndex(window, floor: displayFloor, now: now) {
-            return "\(Int(min(paceCeiling, index).rounded()))% of pace"
+    private static func readingPhrase(
+        _ window: UsageWindow,
+        mode: PercentMode,
+        timing: Timing
+    ) -> String {
+        if mode == .target, let index = paceIndex(window, floor: displayFloor, timing: timing) {
+            return "\(Int(min(paceCeiling, index).rounded()))% of target"
         }
         return "\(Int(window.percent.rounded()))% of \(phrase(window.label))"
     }
@@ -309,17 +397,47 @@ enum Pace {
     /// Nil when the reading is missing or carried over from an earlier poll:
     /// what happened is said once, in the notice above the list, and a verdict
     /// read off stale numbers would be stated with more confidence than it has.
-    static func note(_ provider: Provider, now: Date = Date()) -> (text: String, color: Color)? {
+    static func note(
+        _ provider: Provider,
+        timing: Timing = Timing()
+    ) -> (text: String, color: Color)? {
         guard provider.ok, !provider.stale else { return nil }
-        guard let worst = provider.windows.max(by: { severity($0, now: now) < severity($1, now: now) })
+        guard let worst = provider.windows.max(by: {
+            severity($0, timing: timing) < severity($1, timing: timing)
+        })
         else { return ("no windows", .white.opacity(0.45)) }
 
         if worst.percent < 5 { return ("barely touched", .white.opacity(0.45)) }
-        switch severityTier(worst, now: now) {
+        switch severityTier(worst, timing: timing) {
         case 2 where worst.percent >= 90: return ("nearly out", bad)
-        case 2: return ("over budget", bad)
-        case 1: return ("ahead of pace", warn)
-        default: return ("under budget", good)
+        case 2: return ("well above target", bad)
+        case 1: return ("above target", warn)
+        default: return ("on target", good)
+        }
+    }
+
+    private static func basisReading(_ target: Target, timing: Timing) -> String {
+        switch target.basis {
+        case .workingHours:
+            return "\(Int(target.percent.rounded()))% target based on working hours"
+        case .wallClock where timing.schedule.enabled:
+            return "\(Int(target.percent.rounded()))% target based on wall clock"
+        case .wallClock:
+            return "\(Int(target.percent.rounded()))% target"
+        }
+    }
+
+    private static func basisSentence(_ target: Target, timing: Timing) -> String {
+        guard timing.schedule.enabled else { return "" }
+        switch target.basis {
+        case .workingHours:
+            return " The target uses working hours."
+        case .wallClock where !timing.schedule.isValid:
+            return " The target uses wall clock because the working-hours range is invalid."
+        case .wallClock where !timing.schedule.isActive(at: timing.now, calendar: timing.calendar):
+            return " The target uses wall clock outside working hours."
+        case .wallClock:
+            return " The target uses wall clock because this window contains no working hours."
         }
     }
 

--- a/Sources/AIUsage/PanelView.swift
+++ b/Sources/AIUsage/PanelView.swift
@@ -433,10 +433,13 @@ private struct WorkdayPicker: View {
     let enabled: Bool
     let setSelected: (WorkSchedule.Weekday, Bool) -> Void
 
+    @FocusState private var focusedDay: WorkSchedule.Weekday?
+
     var body: some View {
         HStack(spacing: 4) {
             ForEach(WorkSchedule.Weekday.mondayFirst) { day in
                 let chosen = selected.contains(day)
+                let focused = focusedDay == day
                 Button {
                     setSelected(day, !chosen)
                 } label: {
@@ -452,10 +455,16 @@ private struct WorkdayPicker: View {
                             )
                         )
                         .overlay(
-                            Circle().strokeBorder(Color.white.opacity(chosen ? 0.17 : 0.08))
+                            ZStack {
+                                Circle().strokeBorder(Color.white.opacity(chosen ? 0.17 : 0.08))
+                                if focused {
+                                    Circle().strokeBorder(Color.accentColor, lineWidth: 2)
+                                }
+                            }
                         )
                 }
                 .buttonStyle(.plain)
+                .focused($focusedDay, equals: day)
                 .focusEffectDisabled()
                 .disabled(!enabled || (chosen && selected.count == 1))
                 .accessibilityLabel(day.accessibilityLabel)

--- a/Sources/AIUsage/PanelView.swift
+++ b/Sources/AIUsage/PanelView.swift
@@ -94,6 +94,7 @@ private struct SettingsTab: View {
                 VStack(alignment: .leading, spacing: 14) {
                     menuBarGroup
                     displayGroup
+                    workingHoursGroup
                     alertsGroup
                     refreshGroup
                 }
@@ -173,11 +174,10 @@ private struct SettingsTab: View {
 
             DividedRows {
                 SettingRow(
-                    title: "Percentages show",
-                    subtitle: "the gauges always fill to the budget spent"
+                    title: "Percentages show"
                 ) {
                     GlassSegmented(
-                        options: [.init(Pace.PercentMode.budget, "Budget"), .init(.pace, "Pace")],
+                        options: [.init(Pace.PercentMode.budget, "Used"), .init(.target, "Vs target")],
                         selection: $preferences.percentMode,
                         fontSize: 11,
                         verticalPadding: 4
@@ -187,6 +187,14 @@ private struct SettingsTab: View {
                         store.iconPreferenceChanged()
                     }
                 }
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Target is where usage should be now to spend the quota evenly before reset.")
+                        .foregroundStyle(Glass.ink(0.62))
+                    Text("Gauges always show quota used. Working hours affect the target when active.")
+                        .foregroundStyle(Glass.ink(0.42))
+                }
+                .font(.system(size: 11))
+                .fixedSize(horizontal: false, vertical: true)
                 SettingRow(title: "Card on desktop") {
                     GlassSwitch(isOn: $preferences.showDesktopCard)
                 }
@@ -228,7 +236,7 @@ private struct SettingsTab: View {
                 )
 
                 threshold(
-                    title: "Alert when burning faster than",
+                    title: "Alert above target",
                     value: String(format: "%.1f×", preferences.paceThreshold),
                     isOn: $preferences.paceAlertsEnabled,
                     slider: $preferences.paceThreshold,
@@ -239,6 +247,60 @@ private struct SettingsTab: View {
                 )
             }
             .glassGroup()
+        }
+    }
+
+    private var workingHoursGroup: some View {
+        let schedule = preferences.workSchedule
+
+        return Group {
+            groupTitle("Working hours")
+
+            DividedRows {
+                SettingRow(
+                    title: "Use working hours for target",
+                    subtitle: "spreads each quota across your selected hours"
+                ) {
+                    GlassSwitch(isOn: $preferences.workingHoursEnabled)
+                }
+
+                SettingRow(title: "Days", enabled: preferences.workingHoursEnabled) {
+                    WorkdayPicker(
+                        selected: preferences.workingWeekdays,
+                        enabled: preferences.workingHoursEnabled
+                    ) { day, selected in
+                        preferences.setWorkingDay(day, enabled: selected)
+                    }
+                }
+
+                SettingRow(title: "Hours", enabled: preferences.workingHoursEnabled) {
+                    HStack(spacing: 7) {
+                        MinuteTimePicker(
+                            minute: $preferences.workingStartMinute,
+                            accessibilityLabel: "Working hours start",
+                            enabled: preferences.workingHoursEnabled
+                        )
+                        Text("to")
+                            .font(.system(size: 11))
+                            .foregroundStyle(Glass.ink(preferences.workingHoursEnabled ? 0.45 : 0.3))
+                        MinuteTimePicker(
+                            minute: $preferences.workingEndMinute,
+                            accessibilityLabel: "Working hours end",
+                            enabled: preferences.workingHoursEnabled
+                        )
+                    }
+                }
+
+                HStack(spacing: 7) {
+                    Circle()
+                        .fill(workingStatusColor(schedule))
+                        .frame(width: 5, height: 5)
+                    Text(workingStatus(schedule))
+                        .font(.system(size: 11))
+                        .foregroundStyle(Glass.ink(preferences.workingHoursEnabled ? 0.58 : 0.4))
+                    Spacer(minLength: 0)
+                }
+            }
         }
     }
 
@@ -329,6 +391,22 @@ private struct SettingsTab: View {
         }
     }
 
+    private func workingStatus(_ schedule: WorkSchedule) -> String {
+        guard schedule.enabled else { return "Off · target uses wall clock" }
+        guard schedule.isValid else {
+            return "Target uses wall clock · start and end must differ"
+        }
+        return schedule.isActive(at: Date())
+            ? "Target uses working hours"
+            : "Target uses wall clock · outside working hours"
+    }
+
+    private func workingStatusColor(_ schedule: WorkSchedule) -> Color {
+        schedule.enabled && schedule.isValid && schedule.isActive(at: Date())
+            ? Pace.good
+            : Color.white.opacity(0.35)
+    }
+
     /// The last part standing is locked on: a menu bar item with nothing drawn
     /// in it cannot be clicked back open to undo the mistake.
     private func partSwitch(_ isOn: Binding<Bool>) -> some View {
@@ -343,6 +421,88 @@ private struct SettingsTab: View {
             .onChange(of: isOn.wrappedValue) { _, _ in
                 store.iconPreferenceChanged()
             }
+    }
+}
+
+// --------------------------------------------------------------------- //
+
+/// Seven independent chips rather than a segmented control: several days are
+/// selected at once, and the last one stays locked on.
+private struct WorkdayPicker: View {
+    let selected: Set<WorkSchedule.Weekday>
+    let enabled: Bool
+    let setSelected: (WorkSchedule.Weekday, Bool) -> Void
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(WorkSchedule.Weekday.mondayFirst) { day in
+                let chosen = selected.contains(day)
+                Button {
+                    setSelected(day, !chosen)
+                } label: {
+                    Text(day.shortLabel)
+                        .font(.system(size: 10, weight: chosen ? .semibold : .regular))
+                        .foregroundStyle(Glass.ink(chosen ? 1 : 0.55))
+                        .frame(width: 22, height: 22)
+                        .background(
+                            Circle().fill(
+                                chosen
+                                    ? Color.white.opacity(0.23)
+                                    : Color.black.opacity(0.18)
+                            )
+                        )
+                        .overlay(
+                            Circle().strokeBorder(Color.white.opacity(chosen ? 0.17 : 0.08))
+                        )
+                }
+                .buttonStyle(.plain)
+                .focusEffectDisabled()
+                .disabled(!enabled || (chosen && selected.count == 1))
+                .accessibilityLabel(day.accessibilityLabel)
+                .accessibilityValue(chosen ? "Selected" : "Not selected")
+            }
+        }
+        .opacity(enabled ? 1 : 0.45)
+    }
+}
+
+/// Native time semantics and locale formatting, with the stored value reduced
+/// to minutes after midnight so its arbitrary date is never persisted.
+private struct MinuteTimePicker: View {
+    @Binding var minute: Int
+    let accessibilityLabel: String
+    let enabled: Bool
+
+    var body: some View {
+        DatePicker(
+            "",
+            selection: Binding(
+                get: { date(for: minute) },
+                set: { date in
+                    let parts = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute], from: date)
+                    minute = (parts.hour ?? 0) * 60 + (parts.minute ?? 0)
+                }
+            ),
+            displayedComponents: .hourAndMinute
+        )
+        .labelsHidden()
+        .datePickerStyle(.field)
+        .controlSize(.small)
+        .fixedSize()
+        .disabled(!enabled)
+        .opacity(enabled ? 1 : 0.45)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private func date(for minute: Int) -> Date {
+        let calendar = Calendar.autoupdatingCurrent
+        let value = min(1439, max(0, minute))
+        return calendar.date(
+            bySettingHour: value / 60,
+            minute: value % 60,
+            second: 0,
+            of: Date()
+        ) ?? Date()
     }
 }
 

--- a/Sources/AIUsage/Preferences.swift
+++ b/Sources/AIUsage/Preferences.swift
@@ -47,6 +47,33 @@ final class Preferences: ObservableObject {
         didSet { defaults.set(percentMode.rawValue, forKey: Keys.percentMode) }
     }
 
+    /// Optional local schedule used to redistribute the target while the user
+    /// is currently inside it. The provider windows themselves are unchanged.
+    @Published var workingHoursEnabled: Bool {
+        didSet { defaults.set(workingHoursEnabled, forKey: Keys.workingHoursEnabled) }
+    }
+
+    @Published private(set) var workingWeekdays: Set<WorkSchedule.Weekday> {
+        didSet { defaults.set(workSchedule.weekdayMask, forKey: Keys.workingWeekdays) }
+    }
+
+    @Published var workingStartMinute: Int {
+        didSet { defaults.set(workingStartMinute, forKey: Keys.workingStartMinute) }
+    }
+
+    @Published var workingEndMinute: Int {
+        didSet { defaults.set(workingEndMinute, forKey: Keys.workingEndMinute) }
+    }
+
+    var workSchedule: WorkSchedule {
+        WorkSchedule(
+            enabled: workingHoursEnabled,
+            weekdays: workingWeekdays,
+            startMinute: workingStartMinute,
+            endMinute: workingEndMinute
+        )
+    }
+
     /// The free-standing card on the desktop.
     @Published var showDesktopCard: Bool {
         didSet { defaults.set(showDesktopCard, forKey: Keys.showDesktopCard) }
@@ -106,6 +133,10 @@ final class Preferences: ObservableObject {
         static let menuBarSlots = "menuBarSlots"
         static let menuBarFairShare = "menuBarFairShare"
         static let percentMode = "percentMode"
+        static let workingHoursEnabled = "workingHoursEnabled"
+        static let workingWeekdays = "workingWeekdays"
+        static let workingStartMinute = "workingStartMinute"
+        static let workingEndMinute = "workingEndMinute"
         static let showDesktopCard = "showDesktopCard"
         static let desktopCardFloats = "desktopCardFloats"
         static let desktopCardAnchor = "desktopCardAnchor"
@@ -125,6 +156,15 @@ final class Preferences: ObservableObject {
             Keys.menuBarSlots: 1,
             Keys.menuBarFairShare: false,
             Keys.percentMode: Pace.PercentMode.budget.rawValue,
+            Keys.workingHoursEnabled: false,
+            Keys.workingWeekdays: WorkSchedule(
+                enabled: false,
+                weekdays: WorkSchedule.defaultWeekdays,
+                startMinute: 9 * 60,
+                endMinute: 18 * 60
+            ).weekdayMask,
+            Keys.workingStartMinute: 9 * 60,
+            Keys.workingEndMinute: 18 * 60,
             Keys.showDesktopCard: true,
             Keys.desktopCardFloats: false,
             Keys.usageThreshold: 90.0,
@@ -141,6 +181,15 @@ final class Preferences: ObservableObject {
         menuBarFairShare = defaults.bool(forKey: Keys.menuBarFairShare)
         percentMode = defaults.string(forKey: Keys.percentMode)
             .flatMap(Pace.PercentMode.init(rawValue:)) ?? .budget
+        workingHoursEnabled = defaults.bool(forKey: Keys.workingHoursEnabled)
+        workingWeekdays = WorkSchedule(
+            enabled: false,
+            weekdayMask: defaults.integer(forKey: Keys.workingWeekdays),
+            startMinute: defaults.integer(forKey: Keys.workingStartMinute),
+            endMinute: defaults.integer(forKey: Keys.workingEndMinute)
+        ).weekdays
+        workingStartMinute = min(1439, max(0, defaults.integer(forKey: Keys.workingStartMinute)))
+        workingEndMinute = min(1439, max(0, defaults.integer(forKey: Keys.workingEndMinute)))
         showDesktopCard = defaults.bool(forKey: Keys.showDesktopCard)
         desktopCardFloats = defaults.bool(forKey: Keys.desktopCardFloats)
         usageThreshold = defaults.double(forKey: Keys.usageThreshold)
@@ -148,6 +197,19 @@ final class Preferences: ObservableObject {
         paceThreshold = defaults.double(forKey: Keys.paceThreshold)
         paceAlertsEnabled = defaults.bool(forKey: Keys.paceAlerts)
         refreshMinutes = defaults.double(forKey: Keys.refreshMinutes)
+    }
+
+    /// The last selected weekday cannot be removed: an enabled empty schedule
+    /// would look configured while silently behaving like wall clock.
+    func setWorkingDay(_ day: WorkSchedule.Weekday, enabled: Bool) {
+        var next = workingWeekdays
+        if enabled {
+            next.insert(day)
+        } else {
+            guard next.count > 1 else { return }
+            next.remove(day)
+        }
+        workingWeekdays = next
     }
 
     // ----------------------------------------------------------------- //

--- a/Sources/AIUsage/Report.swift
+++ b/Sources/AIUsage/Report.swift
@@ -170,13 +170,15 @@ struct Report: Codable, Equatable {
     func busiestWindows(
         limit: Int,
         fairShare: Bool = false,
-        now: Date = Date()
+        timing: Pace.Timing = Pace.Timing()
     ) -> [(provider: Provider, window: UsageWindow)] {
         guard limit > 0 else { return [] }
         let ranked = providers
             .filter(\.ok)
             .flatMap { provider in provider.windows.map { (provider: provider, window: $0) } }
-            .sorted { Pace.severity($0.window, now: now) > Pace.severity($1.window, now: now) }
+            .sorted {
+                Pace.severity($0.window, timing: timing) > Pace.severity($1.window, timing: timing)
+            }
 
         guard fairShare else { return Array(ranked.prefix(limit)) }
 

--- a/Sources/AIUsage/StatusIcon.swift
+++ b/Sources/AIUsage/StatusIcon.swift
@@ -16,7 +16,7 @@ enum StatusIcon {
         var window: String = ""
         /// Fills the ring. Always the share of the budget spent, whichever
         /// reading the text beside it quotes — a ring needs a number with an
-        /// end to it, and pace has none.
+        /// end to it, and a pace rate has none.
         var percent: Double?
         /// The percentage as printed, already formatted by `Pace.reading` so
         /// that the icon has no say in which of the two readings it is.

--- a/Sources/AIUsage/UsageCard.swift
+++ b/Sources/AIUsage/UsageCard.swift
@@ -39,9 +39,11 @@ struct RowMetrics {
 struct DesktopUsageCard: View {
     @EnvironmentObject private var store: UsageStore
     @ObservedObject private var preferences = Preferences.shared
+    var timing: Pace.Timing?
 
     var body: some View {
-        let verdict = Pace.verdict(store.report, mode: preferences.percentMode)
+        let timing = timing ?? Pace.Timing(schedule: preferences.workSchedule)
+        let verdict = Pace.verdict(store.report, mode: preferences.percentMode, timing: timing)
 
         VStack(alignment: .leading, spacing: 18) {
             header(verdict)
@@ -56,6 +58,7 @@ struct DesktopUsageCard: View {
                         provider: provider,
                         metrics: .card,
                         mode: preferences.percentMode,
+                        timing: timing,
                         worstRow: verdict.rowKey
                     )
                 }
@@ -69,10 +72,10 @@ struct DesktopUsageCard: View {
 
     private func header(_ verdict: Pace.Verdict) -> some View {
         HStack(spacing: 14) {
-            PaceRing(
+            UsageRing(
                 percent: verdict.percent,
                 color: verdict.color,
-                elapsed: verdict.elapsed,
+                target: verdict.target,
                 size: 40
             )
 
@@ -112,7 +115,8 @@ struct MenuUsageView: View {
     @ObservedObject private var preferences = Preferences.shared
 
     var body: some View {
-        let verdict = Pace.verdict(store.report, mode: preferences.percentMode)
+        let timing = Pace.Timing(schedule: preferences.workSchedule)
+        let verdict = Pace.verdict(store.report, mode: preferences.percentMode, timing: timing)
 
         VStack(alignment: .leading, spacing: 16) {
             summary(verdict)
@@ -126,6 +130,7 @@ struct MenuUsageView: View {
                             provider: provider,
                             metrics: .menu,
                             mode: preferences.percentMode,
+                            timing: timing,
                             showsNote: false,
                             worstRow: verdict.rowKey
                         )
@@ -141,10 +146,10 @@ struct MenuUsageView: View {
 
     private func summary(_ verdict: Pace.Verdict) -> some View {
         HStack(spacing: 12) {
-            PaceRing(
+            UsageRing(
                 percent: verdict.percent,
                 color: verdict.color,
-                elapsed: verdict.elapsed,
+                target: verdict.target,
                 size: 36
             )
 
@@ -220,13 +225,14 @@ struct ProviderBlock: View {
     /// from `Preferences` here, so one observer at the top of each surface
     /// redraws the whole list.
     var mode: Pace.PercentMode = .budget
+    var timing = Pace.Timing()
     var showsNote: Bool = true
     /// The row the summary above is speaking for, marked here so the reader can
     /// trace the ring back to the window it came from.
     var worstRow: String? = nil
 
     var body: some View {
-        let note = Pace.note(provider)
+        let note = Pace.note(provider, timing: timing)
 
         VStack(alignment: .leading, spacing: metrics.trackHeight == 10 ? 10 : 9) {
             HStack(alignment: .firstTextBaseline, spacing: 9) {
@@ -262,6 +268,7 @@ struct ProviderBlock: View {
                         window: window,
                         metrics: metrics,
                         mode: mode,
+                        timing: timing,
                         isWorst: worstRow == Report.rowKey(provider: provider, window: window)
                     )
                 }
@@ -324,17 +331,18 @@ struct UsageRow: View {
     let window: UsageWindow
     let metrics: RowMetrics
     var mode: Pace.PercentMode = .budget
+    var timing = Pace.Timing()
     var isWorst: Bool = false
 
     var body: some View {
-        let reading = Pace.reading(window, mode: mode)
+        let reading = Pace.reading(window, mode: mode, timing: timing)
 
         HStack(spacing: metrics.gap) {
             // The dot sits in a gutter every row pays for, so marking a row
             // moves nothing.
             HStack(spacing: 5) {
                 Circle()
-                    .fill(isWorst ? Pace.color(window) : .clear)
+                    .fill(isWorst ? Pace.color(window, timing: timing) : .clear)
                     .frame(width: 4, height: 4)
 
                 Text(window.label)
@@ -345,15 +353,15 @@ struct UsageRow: View {
 
             UsageTrack(
                 percent: window.percent,
-                elapsed: Pace.elapsedPercent(window),
-                palette: Pace.palette(window),
+                target: Pace.targetPercent(window, timing: timing),
+                palette: Pace.palette(window, timing: timing),
                 height: metrics.trackHeight,
                 glows: metrics.glows
             )
 
             // Dimmed when there is nothing to report and when the window is too
-            // young to have a pace, so a dash reads as "not yet" rather than as
-            // a reading in its own right.
+            // young to have a stable target comparison, so a dash reads as
+            // "not yet" rather than as a reading in its own right.
             Text(reading.text)
                 .font(.system(size: metrics.percentSize, weight: .semibold))
                 .monospacedDigit()

--- a/Sources/AIUsage/UsageStore.swift
+++ b/Sources/AIUsage/UsageStore.swift
@@ -205,6 +205,9 @@ final class UsageStore: ObservableObject {
 
     private func clockContextChanged() {
         redrawIcon()
+        if let report {
+            Notifier.evaluate(report, evaluateUsage: false)
+        }
         scheduleNextBoundary()
     }
 

--- a/Sources/AIUsage/UsageStore.swift
+++ b/Sources/AIUsage/UsageStore.swift
@@ -27,25 +27,72 @@ final class UsageStore: ObservableObject {
 
     static var cacheURL: URL { stateDirectory.appendingPathComponent("usage.json") }
 
-    private var timer: Timer?
-    private var preferenceWatch: AnyCancellable?
+    private var refreshTimer: Timer?
+    private var scheduleBoundaryTimer: Timer?
+    private var workSchedule = WorkSchedule.disabled
+    private var preferenceWatches: Set<AnyCancellable> = []
+    private var clockObservers: [NSObjectProtocol] = []
 
     private init() {
+        let preferences = Preferences.shared
+        workSchedule = preferences.workSchedule
         loadCache()
         redrawIcon()
 
-        preferenceWatch = Preferences.shared.$refreshMinutes
+        preferences.$refreshMinutes
             .removeDuplicates()
             .sink { [weak self] minutes in self?.scheduleTimer(minutes: minutes) }
+            .store(in: &preferenceWatches)
 
-        NSWorkspace.shared.notificationCenter.addObserver(
-            forName: NSWorkspace.didWakeNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in self?.refreshIfStale(olderThan: 300) }
+        Publishers.CombineLatest4(
+            preferences.$workingHoursEnabled,
+            preferences.$workingWeekdays,
+            preferences.$workingStartMinute,
+            preferences.$workingEndMinute
+        )
+        .map { enabled, weekdays, start, end in
+            WorkSchedule(
+                enabled: enabled,
+                weekdays: weekdays,
+                startMinute: start,
+                endMinute: end
+            )
         }
+        .removeDuplicates()
+        .dropFirst()
+        .sink { [weak self] schedule in
+            self?.workScheduleChanged(schedule)
+        }
+        .store(in: &preferenceWatches)
 
+        clockObservers = [
+            NSWorkspace.shared.notificationCenter.addObserver(
+                forName: NSWorkspace.didWakeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.clockContextChanged()
+                    self?.refreshIfStale(olderThan: 300)
+                }
+            },
+            NotificationCenter.default.addObserver(
+                forName: .NSSystemClockDidChange,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in self?.clockContextChanged() }
+            },
+            NotificationCenter.default.addObserver(
+                forName: .NSSystemTimeZoneDidChange,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in self?.clockContextChanged() }
+            },
+        ]
+
+        scheduleNextBoundary()
         Task { await refresh() }
     }
 
@@ -57,10 +104,15 @@ final class UsageStore: ObservableObject {
     }
 
     /// What the menu bar speaks for.
-    func menuBarWindows(limit: Int) -> [(provider: Provider, window: UsageWindow)] {
-        report?.busiestWindows(
+    func menuBarWindows(
+        limit: Int,
+        timing: Pace.Timing? = nil
+    ) -> [(provider: Provider, window: UsageWindow)] {
+        let timing = timing ?? Pace.Timing(schedule: workSchedule)
+        return report?.busiestWindows(
             limit: limit,
-            fairShare: Preferences.shared.menuBarFairShare
+            fairShare: Preferences.shared.menuBarFairShare,
+            timing: timing
         ) ?? []
     }
 
@@ -85,7 +137,7 @@ final class UsageStore: ObservableObject {
     // ----------------------------------------------------------------- //
 
     private func scheduleTimer(minutes: Double) {
-        timer?.invalidate()
+        refreshTimer?.invalidate()
         let interval = max(60, minutes * 60)
         let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
             Task { @MainActor in await self?.refresh() }
@@ -93,34 +145,40 @@ final class UsageStore: ObservableObject {
         // Let the system coalesce the wake-up; a minute either way is fine.
         timer.tolerance = interval * 0.2
         RunLoop.main.add(timer, forMode: .common)
-        self.timer = timer
+        refreshTimer = timer
     }
 
     private func redrawIcon() {
         let preferences = Preferences.shared
-        let shown = menuBarWindows(limit: preferences.menuBarSlots)
+        let timing = Pace.Timing(schedule: workSchedule)
+        let shown = menuBarWindows(limit: preferences.menuBarSlots, timing: timing)
         let segments = shown.map {
             StatusIcon.Segment(
                 provider: $0.provider.name,
                 window: $0.window.label,
                 percent: $0.window.percent,
-                text: Pace.reading($0.window, mode: preferences.percentMode).text,
-                color: Pace.color($0.window)
+                text: Pace.reading(
+                    $0.window,
+                    mode: preferences.percentMode,
+                    timing: timing
+                ).text,
+                color: Pace.color($0.window, timing: timing)
             )
         }
 
         // One line per segment drawn, in the order they appear in the bar, and
-        // the sentence explaining pace once at the end rather than on each.
+        // the sentence explaining the target once at the end rather than on each.
         let lines = shown.map {
             Pace.tooltip(
                 source: "\($0.provider.name) \($0.window.label)",
                 window: $0.window,
-                explains: false
+                explains: false,
+                timing: timing
             )
         }
         statusTooltip = lines.isEmpty
             ? "Tokens on Track — no reading yet"
-            : (lines + [Pace.paceExplainer]).joined(separator: "\n")
+            : (lines + [Pace.targetExplainer]).joined(separator: "\n")
 
         var parts: StatusIcon.Parts = []
         if preferences.showLogoInMenuBar { parts.insert(.mark) }
@@ -134,6 +192,40 @@ final class UsageStore: ObservableObject {
     /// Re-render after a preference change that only affects the icon.
     func iconPreferenceChanged() {
         redrawIcon()
+    }
+
+    /// Preference edits update every surface immediately but never manufacture
+    /// a notification. Only an actual clock boundary or provider refresh is an
+    /// alert evaluation point.
+    private func workScheduleChanged(_ schedule: WorkSchedule) {
+        workSchedule = schedule
+        redrawIcon()
+        scheduleNextBoundary()
+    }
+
+    private func clockContextChanged() {
+        redrawIcon()
+        scheduleNextBoundary()
+    }
+
+    private func scheduleNextBoundary() {
+        scheduleBoundaryTimer?.invalidate()
+        scheduleBoundaryTimer = nil
+        guard let boundary = workSchedule.nextBoundary(after: Date()) else { return }
+
+        let timer = Timer(fire: boundary, interval: 0, repeats: false) { [weak self] _ in
+            Task { @MainActor in
+                guard let self else { return }
+                self.redrawIcon()
+                if let report = self.report {
+                    Notifier.evaluate(report, evaluateUsage: false)
+                }
+                self.scheduleNextBoundary()
+            }
+        }
+        timer.tolerance = 1
+        RunLoop.main.add(timer, forMode: .common)
+        scheduleBoundaryTimer = timer
     }
 
     private func loadCache() {

--- a/Sources/AIUsage/WorkSchedule.swift
+++ b/Sources/AIUsage/WorkSchedule.swift
@@ -1,0 +1,205 @@
+import Foundation
+
+/// The part of the week the user intends to spend quota in. Times are stored as
+/// minutes after local midnight so the preference survives time-zone changes;
+/// concrete intervals are rebuilt with the current calendar whenever a target is
+/// calculated.
+struct WorkSchedule: Equatable {
+    enum Weekday: Int, CaseIterable, Hashable, Identifiable {
+        case sunday = 1
+        case monday
+        case tuesday
+        case wednesday
+        case thursday
+        case friday
+        case saturday
+
+        var id: Int { rawValue }
+
+        static let mondayFirst: [Weekday] = [
+            .monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday,
+        ]
+
+        var shortLabel: String {
+            switch self {
+            case .monday: return "M"
+            case .tuesday: return "T"
+            case .wednesday: return "W"
+            case .thursday: return "T"
+            case .friday: return "F"
+            case .saturday: return "S"
+            case .sunday: return "S"
+            }
+        }
+
+        var accessibilityLabel: String {
+            switch self {
+            case .sunday: return "Sunday"
+            case .monday: return "Monday"
+            case .tuesday: return "Tuesday"
+            case .wednesday: return "Wednesday"
+            case .thursday: return "Thursday"
+            case .friday: return "Friday"
+            case .saturday: return "Saturday"
+            }
+        }
+    }
+
+    var enabled: Bool
+    var weekdays: Set<Weekday>
+    var startMinute: Int
+    var endMinute: Int
+
+    static let defaultWeekdays: Set<Weekday> = [
+        .monday, .tuesday, .wednesday, .thursday, .friday,
+    ]
+
+    static let disabled = WorkSchedule(
+        enabled: false,
+        weekdays: defaultWeekdays,
+        startMinute: 9 * 60,
+        endMinute: 18 * 60
+    )
+
+    var isValid: Bool {
+        !weekdays.isEmpty && Self.normalized(startMinute) != Self.normalized(endMinute)
+    }
+
+    var weekdayMask: Int {
+        weekdays.reduce(0) { $0 | (1 << ($1.rawValue - 1)) }
+    }
+
+    init(enabled: Bool, weekdays: Set<Weekday>, startMinute: Int, endMinute: Int) {
+        self.enabled = enabled
+        self.weekdays = weekdays
+        self.startMinute = Self.normalized(startMinute)
+        self.endMinute = Self.normalized(endMinute)
+    }
+
+    init(enabled: Bool, weekdayMask: Int, startMinute: Int, endMinute: Int) {
+        let decoded = Set(Weekday.allCases.filter {
+            weekdayMask & (1 << ($0.rawValue - 1)) != 0
+        })
+        self.init(
+            enabled: enabled,
+            weekdays: decoded.isEmpty ? Self.defaultWeekdays : decoded,
+            startMinute: startMinute,
+            endMinute: endMinute
+        )
+    }
+
+    /// True only while the working-hours calculation should be live. An
+    /// overnight shift belongs to the weekday on which it starts.
+    func isActive(at date: Date, calendar: Calendar = .autoupdatingCurrent) -> Bool {
+        guard enabled, isValid else { return false }
+        let today = calendar.startOfDay(for: date)
+        guard let yesterday = calendar.date(byAdding: .day, value: -1, to: today) else {
+            return false
+        }
+        return [yesterday, today].contains { day in
+            interval(startingOn: day, calendar: calendar)?.containsHalfOpen(date) == true
+        }
+    }
+
+    /// Wall seconds covered by configured working intervals inside `range`.
+    /// Building each boundary through `Calendar` makes spring-forward,
+    /// fall-back and time-zone changes part of the interval rather than an
+    /// arithmetic exception.
+    func scheduledSeconds(
+        in range: DateInterval,
+        calendar: Calendar = .autoupdatingCurrent
+    ) -> TimeInterval {
+        guard isValid, range.duration > 0 else { return 0 }
+        var day = calendar.startOfDay(for: range.start)
+        guard let previous = calendar.date(byAdding: .day, value: -1, to: day) else {
+            return 0
+        }
+        day = previous
+
+        let last = calendar.startOfDay(for: range.end)
+        var total: TimeInterval = 0
+
+        while day <= last {
+            if let work = interval(startingOn: day, calendar: calendar) {
+                let start = max(work.start, range.start)
+                let end = min(work.end, range.end)
+                if end > start { total += end.timeIntervalSince(start) }
+            }
+            guard let next = calendar.date(byAdding: .day, value: 1, to: day) else {
+                break
+            }
+            day = next
+        }
+        return total
+    }
+
+    /// The next point at which `isActive` can change, used to refresh the target
+    /// without waiting for the provider polling interval.
+    func nextBoundary(
+        after date: Date,
+        calendar: Calendar = .autoupdatingCurrent
+    ) -> Date? {
+        guard enabled, isValid else { return nil }
+        let today = calendar.startOfDay(for: date)
+        guard var day = calendar.date(byAdding: .day, value: -1, to: today) else {
+            return nil
+        }
+        var candidates: [Date] = []
+
+        // Eight days plus yesterday covers the end of an overnight shift and
+        // the next occurrence of even a single selected weekday.
+        for _ in 0..<10 {
+            if let interval = interval(startingOn: day, calendar: calendar) {
+                if interval.start > date { candidates.append(interval.start) }
+                if interval.end > date { candidates.append(interval.end) }
+            }
+            guard let next = calendar.date(byAdding: .day, value: 1, to: day) else {
+                break
+            }
+            day = next
+        }
+        return candidates.min()
+    }
+
+    // ----------------------------------------------------------------- //
+
+    private func interval(startingOn day: Date, calendar: Calendar) -> DateInterval? {
+        let weekday = calendar.component(.weekday, from: day)
+        guard let selected = Weekday(rawValue: weekday), weekdays.contains(selected),
+              let start = localTime(startMinute, on: day, calendar: calendar)
+        else { return nil }
+
+        let overnight = endMinute < startMinute
+        guard let endDay = overnight
+            ? calendar.date(byAdding: .day, value: 1, to: day)
+            : Optional(day),
+              let end = localTime(endMinute, on: endDay, calendar: calendar),
+              end > start
+        else { return nil }
+        return DateInterval(start: start, end: end)
+    }
+
+    private func localTime(_ minute: Int, on day: Date, calendar: Calendar) -> Date? {
+        let value = Self.normalized(minute)
+        let components = DateComponents(hour: value / 60, minute: value % 60, second: 0)
+        return calendar.nextDate(
+            after: day.addingTimeInterval(-1),
+            matching: components,
+            matchingPolicy: .nextTime,
+            repeatedTimePolicy: .first,
+            direction: .forward
+        )
+    }
+
+    private static func normalized(_ minute: Int) -> Int {
+        min(1439, max(0, minute))
+    }
+}
+
+private extension DateInterval {
+    /// `DateInterval.contains` includes the end; schedules switch to wall clock
+    /// exactly at their end time, so their membership is half-open instead.
+    func containsHalfOpen(_ date: Date) -> Bool {
+        date >= start && date < end
+    }
+}

--- a/Tests/RegressionTests.swift
+++ b/Tests/RegressionTests.swift
@@ -5,6 +5,7 @@ import Foundation
 @main
 enum RegressionTests {
     private static let now = Date(timeIntervalSince1970: 1_000_000)
+    private static let wallTiming = Pace.Timing(now: now)
 
     static func main() {
         testRedHighUsageWindowOutranksGreenWindow()
@@ -23,11 +24,21 @@ enum RegressionTests {
         testCarriedReadingIsDroppedOnceItIsOld()
         testCarriedWindowIsDroppedOnceItHasReset()
         testBudgetModeQuotesTheBudget()
-        testPaceModeQuotesThePaceIndex()
-        testPaceModeSaysNothingWhileTheWindowIsYoung()
+        testTargetModeQuotesThePaceIndex()
+        testTargetModeSaysNothingWhileTheWindowIsYoung()
         testPaceIsPrintedSoonerThanItIsColoured()
         testPaceReadingIsCapped()
         testTooltipStatesBothReadings()
+        testVerdictUsesTargetLanguage()
+        testWorkingHoursRedistributeShortWindow()
+        testWorkingHoursSwitchBackToWallClock()
+        testWorkingHoursSpreadAWeekAcrossAllSelectedHours()
+        testWorkingHoursZeroOverlapFallsBackToWallClock()
+        testWorkingHoursDisabledUsesWallClock()
+        testOvernightScheduleBelongsToItsStartDay()
+        testScheduleRespectsDST()
+        testScheduleUsesTheProvidedTimeZone()
+        testScheduleBoundaryIsExact()
         print("All regression tests passed")
     }
 
@@ -35,7 +46,7 @@ enum RegressionTests {
         let green = window(percent: 80, elapsedPercent: 80)
         let red = window(percent: 95, elapsedPercent: 95)
         check(
-            Pace.severity(green, now: now) < Pace.severity(red, now: now),
+            Pace.severity(green, timing: wallTiming) < Pace.severity(red, timing: wallTiming),
             "95% red window must outrank 80% green window"
         )
     }
@@ -44,7 +55,7 @@ enum RegressionTests {
         let green = window(percent: 80, elapsedPercent: 80)
         let red = window(percent: 50, elapsedPercent: 25)
         check(
-            Pace.severity(green, now: now) < Pace.severity(red, now: now),
+            Pace.severity(green, timing: wallTiming) < Pace.severity(red, timing: wallTiming),
             "red pace window must outrank higher-percentage green window"
         )
     }
@@ -82,7 +93,7 @@ enum RegressionTests {
     private static func testBusiestWindowsIgnoreWhoOwnsThem() {
         // Two busy Claude windows and one idle Codex one: asking for the two
         // busiest has to mean exactly that, twice the same provider included.
-        let picked = twoProviderReport().busiestWindows(limit: 2, now: now)
+        let picked = twoProviderReport().busiestWindows(limit: 2, timing: wallTiming)
         check(
             picked.map(\.provider.name) == ["Claude", "Claude"],
             "the busiest windows must be the busiest, whoever owns them"
@@ -94,7 +105,11 @@ enum RegressionTests {
     }
 
     private static func testFairShareGivesEveryProviderASlot() {
-        let picked = twoProviderReport().busiestWindows(limit: 2, fairShare: true, now: now)
+        let picked = twoProviderReport().busiestWindows(
+            limit: 2,
+            fairShare: true,
+            timing: wallTiming
+        )
         check(
             picked.map(\.provider.name) == ["Claude", "Codex"],
             "fair share must seat a second provider before the first repeats"
@@ -102,7 +117,11 @@ enum RegressionTests {
     }
 
     private static func testFairShareSpendsSpareSlotsOnTheNextWorstWindow() {
-        let picked = twoProviderReport().busiestWindows(limit: 3, fairShare: true, now: now)
+        let picked = twoProviderReport().busiestWindows(
+            limit: 3,
+            fairShare: true,
+            timing: wallTiming
+        )
         check(
             picked.map(\.provider.name) == ["Claude", "Codex", "Claude"],
             "a spare slot must go to the next worst window, whoever owns it"
@@ -280,30 +299,43 @@ enum RegressionTests {
     private static func testBudgetModeQuotesTheBudget() {
         // Half the budget a quarter of the way in — 50 against the budget, 200
         // against the clock. Budget mode must not be tempted by the latter.
-        let reading = Pace.reading(window(percent: 50, elapsedPercent: 25), mode: .budget, now: now)
+        let reading = Pace.reading(
+            window(percent: 50, elapsedPercent: 25),
+            mode: .budget,
+            timing: wallTiming
+        )
         check(reading.text == "50%", "budget mode must quote the budget, got \(reading.text)")
         check(reading.hasValue, "a budget reading always has a value")
     }
 
-    private static func testPaceModeQuotesThePaceIndex() {
-        let reading = Pace.reading(window(percent: 50, elapsedPercent: 25), mode: .pace, now: now)
-        check(reading.text == "200%", "pace mode must quote the pace index, got \(reading.text)")
+    private static func testTargetModeQuotesThePaceIndex() {
+        let reading = Pace.reading(
+            window(percent: 50, elapsedPercent: 25),
+            mode: .target,
+            timing: wallTiming
+        )
+        check(reading.text == "200%", "target mode must quote the pace index, got \(reading.text)")
         check(reading.hasValue, "a pace index that exists is a value")
+        check(Pace.PercentMode.target.rawValue == "pace", "target mode must preserve the legacy preference")
     }
 
-    private static func testPaceModeSaysNothingWhileTheWindowIsYoung() {
+    private static func testTargetModeSaysNothingWhileTheWindowIsYoung() {
         // The budget number must NOT stand in here. Both readings share one
-        // column, so a budget percentage printed under a pace heading is
-        // indistinguishable from a pace one and quietly means something else —
-        // which is exactly how "2% of pace" and "2% of budget" came to look
+        // column, so a budget percentage printed under a target heading is
+        // indistinguishable from a target one and quietly means something else —
+        // which is exactly how "2% of target" and "2% of budget" came to look
         // like the same reading for a window that had just reset.
-        let reading = Pace.reading(window(percent: 3, elapsedPercent: 0.5), mode: .pace, now: now)
+        let reading = Pace.reading(
+            window(percent: 3, elapsedPercent: 0.5),
+            mode: .target,
+            timing: wallTiming
+        )
         check(
             reading.text == Pace.noReading,
-            "a window too young for a pace must print a dash, got \(reading.text)"
+            "a window too young for a target comparison must print a dash, got \(reading.text)"
         )
-        check(!reading.hasValue, "an absent pace must not claim to have a value")
-        check(reading.text != "3%", "the budget number must never stand in for a pace")
+        check(!reading.hasValue, "an absent target comparison must not claim to have a value")
+        check(reading.text != "3%", "the budget number must never stand in for a target comparison")
     }
 
     private static func testPaceIsPrintedSoonerThanItIsColoured() {
@@ -312,44 +344,315 @@ enum RegressionTests {
         // decide which window the menu bar speaks for.
         let young = window(percent: 2, elapsedPercent: 2)
         check(
-            Pace.reading(young, mode: .pace, now: now).text == "100%",
+            Pace.reading(young, mode: .target, timing: wallTiming).text == "100%",
             "a window past the display floor must print its pace"
         )
         check(
-            Pace.ratio(young, now: now) == nil,
+            Pace.ratio(young, timing: wallTiming) == nil,
             "the same window must still be too young to be given a severity tier"
         )
     }
 
     private static func testPaceReadingIsCapped() {
-        // 100% of the budget spent in 5% of the window is 2000% of pace, which
+        // 100% of the budget spent against a 5% target is a 2000% pace index,
         // would widen the menu bar item without telling the reader anything.
         let runaway = window(percent: 100, elapsedPercent: 5)
-        let reading = Pace.reading(runaway, mode: .pace, now: now)
+        let reading = Pace.reading(runaway, mode: .target, timing: wallTiming)
         check(reading.text == "999%", "a runaway pace must be capped, got \(reading.text)")
 
-        let tooltip = Pace.tooltip(source: nil, window: runaway, now: now)
+        let tooltip = Pace.tooltip(source: nil, window: runaway, timing: wallTiming)
         check(
-            tooltip.contains("999% of pace"),
+            tooltip.contains("999% of target"),
             "the tooltip must agree with the capped pace reading, got \(tooltip)"
         )
-        check(!tooltip.contains("2000% of pace"), "the tooltip must not expose the uncapped reading")
+        check(!tooltip.contains("2000% of target"), "the tooltip must not expose the uncapped reading")
     }
 
     private static func testTooltipStatesBothReadings() {
         let tooltip = Pace.tooltip(
             source: "Claude 5h",
             window: window(percent: 50, elapsedPercent: 25),
-            now: now
+            timing: wallTiming
         )
-        for expected in ["Claude 5h", "200% of pace", "50% of the budget", "25% of the window"] {
+        for expected in ["Claude 5h", "200% of target", "50% of the budget", "25% target"] {
             check(tooltip.contains(expected), "tooltip must state \(expected), got: \(tooltip)")
         }
 
-        // With no pace to state it has to say why rather than quote a number.
-        let young = Pace.tooltip(source: nil, window: window(percent: 3, elapsedPercent: 2), now: now)
-        check(!young.contains("of pace"), "a window with no pace must not be given one")
+        // With no target comparison to state it has to say why rather than quote a number.
+        let young = Pace.tooltip(
+            source: nil,
+            window: window(percent: 3, elapsedPercent: 2),
+            timing: wallTiming
+        )
+        check(!young.contains("of target"), "a young window must not be given a target comparison")
         check(young.contains("3% of the budget"), "the budget is stated either way")
+    }
+
+    private static func testVerdictUsesTargetLanguage() {
+        let report = Report(
+            providers: [provider(name: "Claude", windows: [window(percent: 50, elapsedPercent: 25)])],
+            date: now
+        )
+        let verdict = Pace.verdict(report, mode: .target, timing: wallTiming)
+        check(verdict.headline == "Well above target", "the verdict must use target language")
+        check(verdict.line.contains("200% of target"), "the verdict must name the target comparison")
+        check(!verdict.line.lowercased().contains("pace"), "user-facing verdicts must not say pace")
+    }
+
+    // ----------------------------------------------------------------- //
+    // Working-hours targets and pace.
+    // ----------------------------------------------------------------- //
+
+    private static func testWorkingHoursRedistributeShortWindow() {
+        let calendar = utcCalendar()
+        let start = date(2026, 7, 27, 17, 0, calendar: calendar)
+        let reset = date(2026, 7, 27, 22, 0, calendar: calendar)
+        let current = date(2026, 7, 27, 18, 0, calendar: calendar)
+        let schedule = WorkSchedule(
+            enabled: true,
+            weekdays: [.monday],
+            startMinute: 17 * 60,
+            endMinute: 19 * 60
+        )
+        let timing = Pace.Timing(now: current, schedule: schedule, calendar: calendar)
+        let quota = quotaWindow(start: start, reset: reset, percent: 20)
+
+        let target = Pace.target(quota, timing: timing)
+        check(target?.basis == .workingHours, "the overlapping short window must use working hours")
+        check(close(target?.percent, 50), "one of two usable hours must produce a 50% target")
+        check(
+            close(Pace.paceIndex(quota, timing: timing), 40),
+            "20% spent against a 50% target must produce a 40% pace index"
+        )
+        check(
+            Pace.tooltip(source: nil, window: quota, timing: timing).contains("working hours"),
+            "the tooltip must name the working-hours basis"
+        )
+    }
+
+    private static func testWorkingHoursSwitchBackToWallClock() {
+        let calendar = utcCalendar()
+        let start = date(2026, 7, 27, 17, 0, calendar: calendar)
+        let reset = date(2026, 7, 27, 22, 0, calendar: calendar)
+        let current = date(2026, 7, 27, 20, 0, calendar: calendar)
+        let schedule = WorkSchedule(
+            enabled: true,
+            weekdays: [.monday],
+            startMinute: 17 * 60,
+            endMinute: 19 * 60
+        )
+        let timing = Pace.Timing(now: current, schedule: schedule, calendar: calendar)
+        let quota = quotaWindow(start: start, reset: reset, percent: 20)
+
+        let target = Pace.target(quota, timing: timing)
+        check(target?.basis == .wallClock, "after 19:00 the same window must use wall clock")
+        check(close(target?.percent, 60), "three of five wall hours must produce a 60% target")
+        check(
+            Pace.tooltip(source: nil, window: quota, timing: timing).contains("wall clock"),
+            "the tooltip must name the wall-clock basis when the feature is enabled"
+        )
+    }
+
+    private static func testWorkingHoursSpreadAWeekAcrossAllSelectedHours() {
+        let calendar = utcCalendar()
+        let start = date(2026, 7, 27, 0, 0, calendar: calendar)
+        let reset = date(2026, 8, 3, 0, 0, calendar: calendar)
+        let schedule = WorkSchedule(
+            enabled: true,
+            weekdays: WorkSchedule.defaultWeekdays,
+            startMinute: 9 * 60,
+            endMinute: 19 * 60
+        )
+        let quota = quotaWindow(start: start, reset: reset, percent: 25)
+
+        let wednesday = Pace.Timing(
+            now: date(2026, 7, 29, 14, 0, calendar: calendar),
+            schedule: schedule,
+            calendar: calendar
+        )
+        let target = Pace.target(quota, timing: wednesday)
+        check(target?.basis == .workingHours, "the weekly window must use its scheduled hours")
+        check(
+            close(target?.percent, 50),
+            "25 of the week's 50 working hours must produce a 50% target"
+        )
+        check(
+            close(Pace.paceIndex(quota, timing: wednesday), 50),
+            "25% spent against a 50% target must produce a 50% pace index"
+        )
+
+        let saturday = Pace.Timing(
+            now: date(2026, 8, 1, 12, 0, calendar: calendar),
+            schedule: schedule,
+            calendar: calendar
+        )
+        let weekend = Pace.target(quota, timing: saturday)
+        check(weekend?.basis == .wallClock, "the weekly window must switch to wall clock on Saturday")
+        check(
+            close(weekend?.percent, 132.0 / 168.0 * 100),
+            "weekend wall-clock progress must keep moving"
+        )
+    }
+
+    private static func testWorkingHoursZeroOverlapFallsBackToWallClock() {
+        let calendar = utcCalendar()
+        let schedule = WorkSchedule(
+            enabled: true,
+            weekdays: [.monday],
+            startMinute: 9 * 60,
+            endMinute: 18 * 60
+        )
+        let current = date(2026, 7, 27, 10, 0, calendar: calendar)
+        let quota = quotaWindow(
+            start: date(2026, 7, 28, 20, 0, calendar: calendar),
+            reset: date(2026, 7, 29, 1, 0, calendar: calendar),
+            percent: 0
+        )
+        let timing = Pace.Timing(now: current, schedule: schedule, calendar: calendar)
+
+        check(
+            Pace.target(quota, timing: timing)?.basis == .wallClock,
+            "a window with no scheduled overlap must fall back to wall clock"
+        )
+    }
+
+    private static func testWorkingHoursDisabledUsesWallClock() {
+        let calendar = utcCalendar()
+        let start = date(2026, 7, 27, 17, 0, calendar: calendar)
+        let reset = date(2026, 7, 27, 22, 0, calendar: calendar)
+        let schedule = WorkSchedule(
+            enabled: false,
+            weekdays: [.monday],
+            startMinute: 17 * 60,
+            endMinute: 19 * 60
+        )
+        let timing = Pace.Timing(
+            now: date(2026, 7, 27, 18, 0, calendar: calendar),
+            schedule: schedule,
+            calendar: calendar
+        )
+        let quota = quotaWindow(start: start, reset: reset, percent: 20)
+
+        let target = Pace.target(quota, timing: timing)
+        check(target?.basis == .wallClock, "a disabled schedule must preserve the wall-clock target")
+        check(close(target?.percent, 20), "one of five wall hours must produce a 20% target")
+        check(
+            Pace.target(UsageWindow(label: "unknown", percent: 10), timing: timing) == nil,
+            "missing reset metadata must still produce no target"
+        )
+
+        let invalid = WorkSchedule(
+            enabled: true,
+            weekdays: [.monday],
+            startMinute: 9 * 60,
+            endMinute: 9 * 60
+        )
+        check(!invalid.isValid, "equal start and end times must be invalid")
+        let invalidTiming = Pace.Timing(
+            now: timing.now,
+            schedule: invalid,
+            calendar: calendar
+        )
+        check(
+            Pace.target(quota, timing: invalidTiming)?.basis == .wallClock,
+            "an invalid schedule must fall back to wall clock"
+        )
+
+        let restored = WorkSchedule(
+            enabled: true,
+            weekdayMask: schedule.weekdayMask,
+            startMinute: schedule.startMinute,
+            endMinute: schedule.endMinute
+        )
+        check(restored.weekdays == schedule.weekdays, "the persisted weekday mask must round-trip")
+    }
+
+    private static func testOvernightScheduleBelongsToItsStartDay() {
+        let calendar = utcCalendar()
+        let schedule = WorkSchedule(
+            enabled: true,
+            weekdays: [.monday],
+            startMinute: 22 * 60,
+            endMinute: 2 * 60
+        )
+        let mondayStart = date(2026, 7, 27, 21, 0, calendar: calendar)
+        let tuesdayEnd = date(2026, 7, 28, 3, 0, calendar: calendar)
+        let range = DateInterval(start: mondayStart, end: tuesdayEnd)
+
+        check(
+            schedule.isActive(
+                at: date(2026, 7, 28, 1, 0, calendar: calendar),
+                calendar: calendar
+            ),
+            "Tuesday 01:00 must belong to Monday's overnight shift"
+        )
+        check(
+            close(schedule.scheduledSeconds(in: range, calendar: calendar), 4 * 3600),
+            "the overnight shift must contribute four hours"
+        )
+    }
+
+    private static func testScheduleRespectsDST() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Europe/Paris")!
+        let schedule = WorkSchedule(
+            enabled: true,
+            weekdays: [.sunday],
+            startMinute: 60,
+            endMinute: 4 * 60
+        )
+
+        let spring = DateInterval(
+            start: date(2026, 3, 29, 0, 0, calendar: calendar),
+            end: date(2026, 3, 30, 0, 0, calendar: calendar)
+        )
+        let autumn = DateInterval(
+            start: date(2026, 10, 25, 0, 0, calendar: calendar),
+            end: date(2026, 10, 26, 0, 0, calendar: calendar)
+        )
+        check(
+            close(schedule.scheduledSeconds(in: spring, calendar: calendar), 2 * 3600),
+            "01:00–04:00 must contain two wall hours across spring-forward"
+        )
+        check(
+            close(schedule.scheduledSeconds(in: autumn, calendar: calendar), 4 * 3600),
+            "01:00–04:00 must contain four wall hours across fall-back"
+        )
+    }
+
+    private static func testScheduleUsesTheProvidedTimeZone() {
+        var utc = utcCalendar()
+        var newYork = Calendar(identifier: .gregorian)
+        newYork.timeZone = TimeZone(identifier: "America/New_York")!
+        let instant = date(2026, 7, 27, 10, 0, calendar: utc)
+        let schedule = WorkSchedule(
+            enabled: true,
+            weekdays: [.monday],
+            startMinute: 9 * 60,
+            endMinute: 18 * 60
+        )
+
+        check(schedule.isActive(at: instant, calendar: utc), "10:00 UTC must be inside the schedule")
+        check(
+            !schedule.isActive(at: instant, calendar: newYork),
+            "the same instant at 06:00 New York time must be outside the schedule"
+        )
+        utc.timeZone = TimeZone(secondsFromGMT: 0)!
+    }
+
+    private static func testScheduleBoundaryIsExact() {
+        let calendar = utcCalendar()
+        let schedule = WorkSchedule(
+            enabled: true,
+            weekdays: [.monday],
+            startMinute: 9 * 60,
+            endMinute: 18 * 60
+        )
+        let before = date(2026, 7, 27, 17, 59, calendar: calendar)
+        let end = date(2026, 7, 27, 18, 0, calendar: calendar)
+
+        check(schedule.nextBoundary(after: before, calendar: calendar) == end, "18:00 is the next boundary")
+        check(!schedule.isActive(at: end, calendar: calendar), "the schedule must be inactive at its end")
     }
 
     // ----------------------------------------------------------------- //
@@ -370,6 +673,45 @@ enum RegressionTests {
             resetsAt: Int(now.timeIntervalSince1970 + remaining),
             windowSeconds: length
         )
+    }
+
+    private static func quotaWindow(start: Date, reset: Date, percent: Double) -> UsageWindow {
+        UsageWindow(
+            label: "quota",
+            percent: percent,
+            resetsAt: Int(reset.timeIntervalSince1970),
+            windowSeconds: Int(reset.timeIntervalSince(start))
+        )
+    }
+
+    private static func utcCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private static func date(
+        _ year: Int,
+        _ month: Int,
+        _ day: Int,
+        _ hour: Int,
+        _ minute: Int,
+        calendar: Calendar
+    ) -> Date {
+        calendar.date(
+            from: DateComponents(
+                year: year,
+                month: month,
+                day: day,
+                hour: hour,
+                minute: minute
+            )
+        )!
+    }
+
+    private static func close(_ actual: Double?, _ expected: Double, tolerance: Double = 0.01) -> Bool {
+        guard let actual else { return false }
+        return abs(actual - expected) <= tolerance
     }
 
     private static func check(_ condition: @autoclosure () -> Bool, _ message: String) {

--- a/test.sh
+++ b/test.sh
@@ -8,6 +8,7 @@ mkdir -p .build
 
 swiftc -parse-as-library \
     Sources/AIUsage/Report.swift \
+    Sources/AIUsage/WorkSchedule.swift \
     Sources/AIUsage/Pace.swift \
     Sources/AIUsage/Fetcher.swift \
     Sources/AIUsage/BrandGlyph.swift \


### PR DESCRIPTION
Adds optional weekday and time-range scheduling so quota targets are paced across working hours, with wall-clock fallback outside the active schedule or when a window has no scheduled overlap.

Updates target calculations across the menu bar, dropdown, desktop card, rankings, tooltips, and notifications, including boundary, time-zone, and wake reevaluation.

Adds settings UI, persisted preferences, DST-aware schedule logic, documentation, regression coverage, and visible keyboard focus for weekday controls.

Validated with `swift build`, `./test.sh`, and `git diff --check`.